### PR TITLE
Give a unique job id to repeatable jobs

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -115,6 +115,15 @@ export class Background {
     }
   ) {
     await this.connect()
+    
+    // `jobId` is used to determine uniqueness along with name and repeat pattern.
+    // Since the name is really a job type and never changes, the `jobId` is the only
+    // way to allow multiple jobs with the same cron repeat pattern. Uniqueness will
+    // now be enforced by combining class name, method name, and cron repeat pattern.
+    //
+    // See: https://docs.bullmq.io/guide/jobs/repeatable
+    const jobId = `${ObjectClass.name}:${method}`
+
     await this.queue!.add(
       'BackgroundJobQueueStaticJob',
       {
@@ -127,8 +136,7 @@ export class Background {
         repeat: {
           pattern,
         },
-        jobId: `${ObjectClass.name}:${method}`,
-
+        jobId,
       }
     )
   }


### PR DESCRIPTION
### What is this?

Currently, there can only ever be one repeatable job with a given cron pattern (`0 * * * *`) because all jobs of a given type are given the same string name. This means the name and repeat options are the same, and BullMQ prevents any additional repeatable jobs from being scheduled. [From BullMQ's docs](https://docs.bullmq.io/guide/jobs/repeatable):

> Bull is smart enough not to add the same repeatable job if the repeat options are the same

There's also a `jobId` option for repeatable jobs, which BullMQ additionally uses to determine uniqueness.

### What it fixes

This change will allow us to have multiple scheduled background jobs with the same cron repeat pattern. The uniqueness constraint will depend on the class name, method name, and cron pattern instead of just the cron pattern.