### PR TITLE
add graceful error handler if conf/app.ts renders any type errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rvohealth/psychic",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "src/index.ts",
   "author": "RVOHealth",
   "repository": "https://github.com/rvohealth/psychic.git",


### PR DESCRIPTION
Currently, wellos-central has an app.ts file which contains errors. If this happens, we should gracefully exit, rather than hard-failing.