### PR TITLE
boost performance for send spec helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rvohealth/psychic",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "main": "src/index.ts",
   "author": "RVOHealth",
   "repository": "https://github.com/rvohealth/psychic.git",

--- a/spec-helpers/send.ts
+++ b/spec-helpers/send.ts
@@ -1,6 +1,6 @@
 import supertest, { Response } from 'supertest'
 import { createPsychicServer } from '.'
-import { HttpMethod } from '../src'
+import { HttpMethod, PsychicServer } from '../src'
 import supersession from './supersession'
 
 export class Send {
@@ -55,7 +55,7 @@ export class Send {
     expectedStatus: number,
     opts: SendOptsAll = {},
   ) {
-    const server = await createPsychicServer()
+    server ||= await createPsychicServer()
 
     const req = supertest(server.app)
     let request = req[method](uri)
@@ -73,6 +73,8 @@ export class Send {
     }
   }
 }
+
+let server: PsychicServer
 
 export interface SendOptsAll extends SendOpts {
   query?: Record<string, unknown>


### PR DESCRIPTION
although it seems a fairly minor change to cache a variable which is already being cached by the underlying function, the cost of waiting for the promise to return, even with a simple caching layer on the other side of the function being consumed, is still high enough to warrant speeding up. Testing this fix in a particularly request-heavy test (it had 32 individual request specs in it) within wellos, the test went from running in `37 seconds` to running in `47 seconds`. Adding this fix sped the test back up to 37 seconds again.