### PR TITLE
ensure flattened serializers are added to schema components

### DIFF
--- a/spec/unit/openapi-renderer/endpoint/toSchemaObject.spec.ts
+++ b/spec/unit/openapi-renderer/endpoint/toSchemaObject.spec.ts
@@ -844,6 +844,57 @@ The following values will be allowed:
           )
         })
 
+        context('flatten=true', () => {
+          it('renders flattened serializers the same as regular serializers', () => {
+            const renderer = new OpenapiEndpointRenderer(Pet, UsersController, 'howyadoin', {
+              serializerKey: 'withFlattenedAssociation',
+            })
+            const response = renderer.toSchemaObject({})
+
+            expect(response).toEqual(
+              expect.objectContaining({
+                PetWithFlattenedAssociation: {
+                  type: 'object',
+                  required: ['user'],
+                  properties: { user: { $ref: '#/components/schemas/UserWithFlattenedPost' } },
+                },
+                UserWithFlattenedPost: {
+                  type: 'object',
+                  required: ['id', 'body', 'comments'],
+                  properties: {
+                    id: { type: 'string' },
+                    body: { type: 'string', nullable: true },
+                    comments: {
+                      type: 'array',
+                      items: { $ref: '#/components/schemas/Comment' },
+                    },
+                  },
+                },
+                PostWithComments: {
+                  type: 'object',
+                  required: ['id', 'body', 'comments'],
+                  properties: {
+                    id: { type: 'string' },
+                    body: { type: 'string', nullable: true },
+                    comments: {
+                      type: 'array',
+                      items: { $ref: '#/components/schemas/Comment' },
+                    },
+                  },
+                },
+                Comment: {
+                  type: 'object',
+                  required: ['id', 'body'],
+                  properties: {
+                    id: { type: 'string' },
+                    body: { type: 'string', nullable: true },
+                  },
+                },
+              }),
+            )
+          })
+        })
+
         context('with a nullable RendersOne', () => {
           it('treats association as nullable', () => {
             const renderer = new OpenapiEndpointRenderer(User, UsersController, 'howyadoin', {

--- a/spec/unit/openapi-renderer/serializer/parse.spec.ts
+++ b/spec/unit/openapi-renderer/serializer/parse.spec.ts
@@ -329,6 +329,15 @@ describe('OpenapiSerializerRenderer', () => {
                 name: { type: 'string', nullable: true },
               },
             },
+            User: {
+              type: 'object',
+              required: ['id', 'email', 'name'],
+              properties: {
+                id: { type: 'integer' },
+                email: { type: 'string' },
+                name: { type: 'string', nullable: true },
+              },
+            },
           })
         })
       })

--- a/src/openapi-renderer/serializer.ts
+++ b/src/openapi-renderer/serializer.ts
@@ -223,17 +223,15 @@ Error: ${this.serializerClass.name} missing explicit serializer definition for $
         break
     }
 
-    if (!association.flatten) {
-      const associatedSchema = new OpenapiSerializerRenderer({
-        serializerClass: associatedSerializer,
-        serializers: this.serializers,
-        schemaDelimeter: this.schemaDelimeter,
-        processedSchemas: this.processedSchemas,
-        target: this.target,
-      }).parse()
+    const associatedSchema = new OpenapiSerializerRenderer({
+      serializerClass: associatedSerializer,
+      serializers: this.serializers,
+      schemaDelimeter: this.schemaDelimeter,
+      processedSchemas: this.processedSchemas,
+      target: this.target,
+    }).parse()
 
-      finalOutput = { ...finalOutput, ...associatedSchema }
-    }
+    finalOutput = { ...finalOutput, ...associatedSchema }
 
     return finalOutput
   }

--- a/test-app/src/app/models/Pet.ts
+++ b/test-app/src/app/models/Pet.ts
@@ -13,6 +13,7 @@ export default class Pet extends ApplicationModel {
       summary: 'PetSummarySerializer',
       additional: 'PetAdditionalSerializer',
       withAssociation: 'PetWithAssociationSerializer',
+      withFlattenedAssociation: 'PetWithFlattenedAssociationSerializer',
     }
   }
 

--- a/test-app/src/app/models/User.ts
+++ b/test-app/src/app/models/User.ts
@@ -22,6 +22,7 @@ export default class User extends ApplicationModel {
       extra: 'UserExtraSerializer',
       withPosts: 'UserWithPostsSerializer',
       withRecentPost: 'UserWithRecentPostSerializer',
+      withFlattenedPost: 'UserWithFlattenedPostSerializer',
     }
   }
 

--- a/test-app/src/app/serializers/PetSerializer.ts
+++ b/test-app/src/app/serializers/PetSerializer.ts
@@ -1,7 +1,6 @@
 import { Attribute, DreamColumn, DreamSerializer, RendersOne } from '@rvohealth/dream'
 import Pet from '../models/Pet'
 import User from '../models/User'
-import UserSerializer from './UserSerializer'
 
 export class PetSummarySerializer extends DreamSerializer {
   @Attribute(Pet)
@@ -19,6 +18,11 @@ export class PetAdditionalSerializer extends PetSummarySerializer {
 }
 
 export class PetWithAssociationSerializer extends DreamSerializer {
-  @RendersOne(() => UserSerializer)
+  @RendersOne(User)
+  public user: User
+}
+
+export class PetWithFlattenedAssociationSerializer extends DreamSerializer {
+  @RendersOne(User, { serializerKey: 'withFlattenedPost' })
   public user: User
 }

--- a/test-app/src/app/serializers/UserSerializer.ts
+++ b/test-app/src/app/serializers/UserSerializer.ts
@@ -1,7 +1,6 @@
 import { Attribute, DreamColumn, DreamSerializer, RendersMany, RendersOne } from '@rvohealth/dream'
 import Post from '../models/Post'
 import User from '../models/User'
-import { PostWithCommentsSerializer, PostWithRecentCommentSerializer } from './PostSerializer'
 
 export class UserSummarySerializer extends DreamSerializer {
   @Attribute(User)
@@ -38,9 +37,13 @@ export class UserExtraSerializer extends UserSummarySerializer {
 }
 
 export class UserWithPostsSerializer extends UserSummarySerializer {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  @RendersMany(() => PostWithCommentsSerializer<any, any>)
+  @RendersMany(Post, { serializerKey: 'withComments' })
   public posts: Post[]
+}
+
+export class UserWithFlattenedPostSerializer extends UserSummarySerializer {
+  @RendersOne(Post, { serializerKey: 'withComments', flatten: true })
+  public post: Post
 }
 
 export class UserWithPostsMultiType2Serializer extends UserSummarySerializer {
@@ -49,7 +52,6 @@ export class UserWithPostsMultiType2Serializer extends UserSummarySerializer {
 }
 
 export class UserWithRecentPostSerializer extends UserSummarySerializer {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  @RendersOne(() => PostWithRecentCommentSerializer<any, any>, { nullable: true })
+  @RendersOne(Post, { nullable: true, serializerKey: 'withRecentComment' })
   public recentPost: Post | null
 }

--- a/test-app/src/db/schema.ts
+++ b/test-app/src/db/schema.ts
@@ -143,7 +143,7 @@ export const schema = {
     createdAtField: 'createdAt',
     updatedAtField: 'updatedAt',
     deletedAtField: 'deletedAt',
-    serializerKeys: ['additional', 'default', 'summary', 'withAssociation'],
+    serializerKeys: ['additional', 'default', 'summary', 'withAssociation', 'withFlattenedAssociation'],
     scopes: {
       default: [],
       named: [],
@@ -819,6 +819,7 @@ export const globalSchema = {
       'PetSerializer',
       'PetSummarySerializer',
       'PetWithAssociationSerializer',
+      'PetWithFlattenedAssociationSerializer',
       'PostSerializer',
       'PostSummarySerializer',
       'PostWithCommentsSerializer',
@@ -826,6 +827,7 @@ export const globalSchema = {
       'UserExtraSerializer',
       'UserSerializer',
       'UserSummarySerializer',
+      'UserWithFlattenedPostSerializer',
       'UserWithPostsMultiType2Serializer',
       'UserWithPostsSerializer',
       'UserWithRecentPostSerializer'


### PR DESCRIPTION
when a nested serializer exists within a flattened serializer chain, it is omitted from schema components, even though it is needed to produce a valid openapi document. This PR fixes this issue.

close https://rvohealth.atlassian.net/browse/PDTC-6392