### PR TITLE
We don't know how users will pull models into scope,

### DIFF
--- a/spec/unit/generate/helpers/generateControllerContent.spec.ts
+++ b/spec/unit/generate/helpers/generateControllerContent.spec.ts
@@ -88,9 +88,9 @@ export default class PostsController extends AuthedController {
   }
 
   private async post() {
-    return await this.currentUser.associationQuery('posts').findOrFail(
-      this.castParam('id', 'string')
-    )
+    // return await this.currentUser.associationQuery('posts').findOrFail(
+    //   this.castParam('id', 'string')
+    // )
   }
 }
 `,
@@ -184,9 +184,9 @@ export default class ApiV1HealthPostsController extends AuthedController {
   }
 
   private async healthPost() {
-    return await this.currentUser.associationQuery('healthPosts').findOrFail(
-      this.castParam('id', 'string')
-    )
+    // return await this.currentUser.associationQuery('healthPosts').findOrFail(
+    //   this.castParam('id', 'string')
+    // )
   }
 }
 `,

--- a/src/generate/helpers/generateControllerContent.ts
+++ b/src/generate/helpers/generateControllerContent.ts
@@ -207,9 +207,9 @@ function privateMethods(modelClassName: string, methods: string[]) {
 
 function loadModelStatement(modelClassName: string) {
   return `  private async ${camelize(modelClassName)}() {
-    return await this.currentUser.associationQuery('${pluralize(camelize(modelClassName))}').findOrFail(
-      this.castParam('id', 'string')
-    )
+    // return await this.currentUser.associationQuery('${pluralize(camelize(modelClassName))}').findOrFail(
+    //   this.castParam('id', 'string')
+    // )
   }`
 }
 


### PR DESCRIPTION
and making the wrong assumption causes type errors that can distract from what one is trying to work on (e.g. focusing on models after using the resource
generator)