### PR TITLE
Include the Job as the last argument to

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rvohealth/psychic",
   "description": "Typescript web framework",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "main": "dist/src/index.js",
   "author": "RVOHealth",
   "repository": "https://github.com/rvohealth/psychic.git",

--- a/spec/unit/background/backgrounded-service.spec.ts
+++ b/spec/unit/background/backgrounded-service.spec.ts
@@ -11,9 +11,14 @@ describe('BackgroundedService', () => {
   describe('.background', () => {
     it('calls the static method, passing args', async () => {
       jest.spyOn(DummyService, 'classRunInBG').mockImplementation(async () => {})
+      jest.spyOn(DummyService, 'classRunInBGWithJobArg').mockImplementation(async () => {})
       await DummyService.background('classRunInBG', 'bottlearum')
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(DummyService.classRunInBG).toHaveBeenCalledWith('bottlearum')
+      expect(DummyService.classRunInBG).toHaveBeenCalledWith('bottlearum', expect.any(Job))
+
+      await DummyService.background('classRunInBGWithJobArg', 'bottlearum')
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(DummyService.classRunInBGWithJobArg).toHaveBeenCalledWith('bottlearum', expect.any(Job))
     })
   })
 
@@ -25,7 +30,11 @@ describe('BackgroundedService', () => {
         constructorArgs: ['bottleawhiskey'],
       })
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(DummyService.prototype.instanceMethodToTest).toHaveBeenCalledWith('bottleawhiskey', 'bottlearum')
+      expect(DummyService.prototype.instanceMethodToTest).toHaveBeenCalledWith(
+        'bottleawhiskey',
+        'bottlearum',
+        expect.any(Job),
+      )
     })
 
     context('queue priority', () => {
@@ -150,7 +159,7 @@ describe('BackgroundedService', () => {
       jest.spyOn(DummyService, 'classRunInBG').mockImplementation(async () => {})
       await DummyService.backgroundWithDelay(25, 'classRunInBG', 'bottlearum')
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(DummyService.classRunInBG).toHaveBeenCalledWith('bottlearum')
+      expect(DummyService.classRunInBG).toHaveBeenCalledWith('bottlearum', expect.any(Job))
     })
   })
 
@@ -163,7 +172,11 @@ describe('BackgroundedService', () => {
       })
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(DummyService.prototype.instanceMethodToTest).toHaveBeenCalledWith('bottleawhiskey', 'bottlearum')
+      expect(DummyService.prototype.instanceMethodToTest).toHaveBeenCalledWith(
+        'bottleawhiskey',
+        'bottlearum',
+        expect.any(Job),
+      )
     })
 
     context('queue priority', () => {

--- a/spec/unit/background/instanceMethod.spec.ts
+++ b/spec/unit/background/instanceMethod.spec.ts
@@ -12,7 +12,7 @@ describe('background (app singleton)', () => {
         constructorArgs: ['bottleawhiskey'],
         globalName: 'services/DummyService',
       })
-      expect(await readTmpFile()).toEqual('bottleawhiskey,bottlearum')
+      expect(await readTmpFile()).toEqual('bottleawhiskey,bottlearum,BackgroundJobQueueInstanceJob')
     })
 
     context('priority', () => {

--- a/spec/unit/background/modelInstanceMethod.spec.ts
+++ b/spec/unit/background/modelInstanceMethod.spec.ts
@@ -14,7 +14,7 @@ describe('background (app singleton)', () => {
       })
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(User.prototype._testBackground).toHaveBeenCalledWith(user.id, 'howyadoin')
+      expect(User.prototype._testBackground).toHaveBeenCalledWith(user.id, 'howyadoin', expect.any(Job))
     })
   })
 

--- a/spec/unit/background/staticMethod.spec.ts
+++ b/spec/unit/background/staticMethod.spec.ts
@@ -13,6 +13,14 @@ describe('background (app singleton)', () => {
       expect(await readTmpFile()).toEqual('bottlearum')
     })
 
+    it('passes the Job as the last argument', async () => {
+      await background.staticMethod(DummyService, 'classRunInBGWithJobArg', {
+        globalName: 'services/DummyService',
+        args: ['bottlearum'],
+      })
+      expect(await readTmpFile()).toEqual('bottlearum,BackgroundJobQueueStaticJob')
+    })
+
     context('priority', () => {
       const subject = async () => {
         await background.staticMethod(DummyService, 'classRunInBG', {

--- a/src/background/backgrounded-service.ts
+++ b/src/background/backgrounded-service.ts
@@ -1,5 +1,7 @@
 import { GlobalNameNotSet } from '@rvohealth/dream'
+import { Job } from 'bullmq'
 import { FunctionPropertyNames } from '../helpers/typeHelpers'
+import { OmitTypeFromArray } from '../psychic-application/types'
 import background, { BackgroundJobConfig } from './'
 
 export default class BackgroundedService {
@@ -21,8 +23,7 @@ export default class BackgroundedService {
     T,
     MethodName extends PsychicBackgroundedServiceStaticMethods<T & typeof BackgroundedService>,
     MethodFunc extends T[MethodName & keyof T],
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    MethodArgs extends MethodFunc extends (...args: any) => any ? Parameters<MethodFunc> : never,
+    MethodArgs extends BackgroundableMethodArgs<MethodFunc>,
   >(this: T, methodName: MethodName, ...args: MethodArgs) {
     const safeThis: typeof BackgroundedService = this as typeof BackgroundedService
 
@@ -37,8 +38,7 @@ export default class BackgroundedService {
     T,
     MethodName extends PsychicBackgroundedServiceStaticMethods<T & typeof BackgroundedService>,
     MethodFunc extends T[MethodName & keyof T],
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    MethodArgs extends MethodFunc extends (...args: any) => any ? Parameters<MethodFunc> : never,
+    MethodArgs extends BackgroundableMethodArgs<MethodFunc>,
   >(this: T, delaySeconds: number, methodName: MethodName, ...args: MethodArgs) {
     const safeThis: typeof BackgroundedService = this as typeof BackgroundedService
 
@@ -54,8 +54,7 @@ export default class BackgroundedService {
     T,
     MethodName extends PsychicBackgroundedServiceInstanceMethods<T & BackgroundedService>,
     MethodFunc extends T[MethodName & keyof T],
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    MethodArgs extends MethodFunc extends (...args: any) => any ? Parameters<MethodFunc> : never,
+    MethodArgs extends BackgroundableMethodArgs<MethodFunc>,
   >(
     this: T,
     methodName: MethodName,
@@ -83,8 +82,7 @@ export default class BackgroundedService {
     T,
     MethodName extends PsychicBackgroundedServiceInstanceMethods<T & BackgroundedService>,
     MethodFunc extends T[MethodName & keyof T],
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    MethodArgs extends MethodFunc extends (...args: any) => any ? Parameters<MethodFunc> : never,
+    MethodArgs extends BackgroundableMethodArgs<MethodFunc>,
   >(
     this: T,
     delaySeconds: number,
@@ -120,3 +118,7 @@ export type PsychicBackgroundedServiceInstanceMethods<T extends BackgroundedServ
   FunctionPropertyNames<Required<T>>,
   FunctionPropertyNames<BackgroundedService>
 >
+
+type BackgroundableMethodArgs<MethodFunc> =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  MethodFunc extends (...args: any) => any ? OmitTypeFromArray<Parameters<MethodFunc>, Job> : never

--- a/src/psychic-application/types.ts
+++ b/src/psychic-application/types.ts
@@ -19,3 +19,11 @@ export type PsychicHookLoadEventTypes = Exclude<
 
 type Only<T, U> = T & Partial<Record<Exclude<keyof U, keyof T>, never>>
 export type Either<T, U> = Only<T, U> | Only<U, T>
+
+export type OmitTypeFromArray<T extends unknown[], TypeToOmit> = T extends []
+  ? []
+  : T extends [infer H, ...infer R]
+    ? H extends TypeToOmit
+      ? OmitTypeFromArray<R, TypeToOmit>
+      : [H, ...OmitTypeFromArray<R, TypeToOmit>]
+    : T

--- a/test-app/src/app/models/User.ts
+++ b/test-app/src/app/models/User.ts
@@ -6,6 +6,7 @@ import {
   Validates,
   Virtual,
 } from '@rvohealth/dream'
+import { Job } from 'bullmq'
 import { randomBytes, scrypt, timingSafeEqual } from 'crypto'
 import ApplicationModel from './ApplicationModel'
 import Pet from './Pet'
@@ -111,12 +112,12 @@ export default class User extends ApplicationModel {
     return await insecurePasswordCompareSinceBcryptBringsInTooMuchGarbage(password, this.passwordDigest)
   }
 
-  public async testBackground(arg: string) {
-    return await this._testBackground(this.id, arg)
+  public async testBackground(arg: string, job: Job) {
+    return await this._testBackground(this.id, arg, job)
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
-  public async _testBackground(userId: any, arg: string) {}
+  public async _testBackground(userId: any, arg: string, job: Job) {}
 }
 
 const keyLength = 64

--- a/test-app/src/app/services/DummyService.ts
+++ b/test-app/src/app/services/DummyService.ts
@@ -1,3 +1,4 @@
+import { Job } from 'bullmq'
 import fs from 'fs/promises'
 import path from 'path'
 import { BackgroundedService, PsychicApplication } from '../../../../src'
@@ -6,8 +7,7 @@ export default class DummyService extends BackgroundedService {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public static async classRunInBG(arg: any) {
     const psychicApp = PsychicApplication.getOrFail()
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    await fs.writeFile(path.join(psychicApp.apiRoot, 'spec/tmp.txt'), arg)
+    await fs.writeFile(path.join(psychicApp.apiRoot, 'spec/tmp.txt'), `${arg}`)
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -20,13 +20,18 @@ export default class DummyService extends BackgroundedService {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public async instanceRunInBG(arg: any) {
-    await this.instanceMethodToTest(this.constructorArg, arg)
+  public async instanceRunInBG(arg: any, job: Job) {
+    await this.instanceMethodToTest(this.constructorArg, arg, job)
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public async instanceMethodToTest(a: any, b: any) {
+  public async instanceMethodToTest(a: any, b: any, job: Job) {
     const psychicApp = PsychicApplication.getOrFail()
-    await fs.writeFile(path.join(psychicApp.apiRoot, 'spec/tmp.txt'), `${a},${b}`)
+    await fs.writeFile(path.join(psychicApp.apiRoot, 'spec/tmp.txt'), `${a},${b},${job.name}`)
+  }
+
+  public static async classRunInBGWithJobArg(arg: 'bottlearum', job: Job) {
+    const psychicApp = PsychicApplication.getOrFail()
+    await fs.writeFile(path.join(psychicApp.apiRoot, 'spec/tmp.txt'), `${arg},${job.name}`)
   }
 }


### PR DESCRIPTION
backgrounded methods so that Job#log(string)
and Job#updateProgress(objectOrNumber) can
be called for long running jobs