### PR TITLE
Fix background job function without Job type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rvohealth/psychic",
   "description": "Typescript web framework",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "main": "dist/src/index.js",
   "author": "RVOHealth",
   "repository": "https://github.com/rvohealth/psychic.git",

--- a/src/psychic-application/types.ts
+++ b/src/psychic-application/types.ts
@@ -19,11 +19,3 @@ export type PsychicHookLoadEventTypes = Exclude<
 
 type Only<T, U> = T & Partial<Record<Exclude<keyof U, keyof T>, never>>
 export type Either<T, U> = Only<T, U> | Only<U, T>
-
-export type OmitTypeFromArray<T extends unknown[], TypeToOmit> = T extends []
-  ? []
-  : T extends [infer H, ...infer R]
-    ? H extends TypeToOmit
-      ? OmitTypeFromArray<R, TypeToOmit>
-      : [H, ...OmitTypeFromArray<R, TypeToOmit>]
-    : T


### PR DESCRIPTION
Previous approach resulted in [string] | [number] | [bigint] when the backgrounded method accepted IdType