### PR TITLE
walk back cli:start hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,7 +6,7 @@ import PsychicApp, { PsychicAppInitOptions } from '../psychic-app/index.js'
 import generateSyncEnumsInitializer from '../generate/initializer/syncEnums.js'
 
 export default class PsychicCLI {
-  public static async provide(
+  public static provide(
     program: Command,
     {
       initializePsychicApp,
@@ -194,9 +194,5 @@ export default class PsychicCLI {
         await PsychicBin.syncClientEnums(outfile)
         process.exit()
       })
-
-    for (const hook of PsychicApp.getOrFail().specialHooks.cliStart) {
-      await hook(program)
-    }
   }
 }

--- a/src/psychic-app/index.ts
+++ b/src/psychic-app/index.ts
@@ -284,7 +284,6 @@ Try setting it to something valid, like:
     serverStart: [],
     serverError: [],
     serverShutdown: [],
-    cliStart: [],
   }
   public get specialHooks() {
     return this._specialHooks
@@ -426,10 +425,6 @@ Try setting it to something valid, like:
 
       case 'server:init:after-routes':
         this._specialHooks.serverInitAfterRoutes.push(cb as (server: PsychicServer) => void | Promise<void>)
-        break
-
-      case 'cli:start':
-        this._specialHooks.cliStart.push(cb as (program: Command) => void | Promise<void>)
         break
 
       case 'sync':
@@ -647,7 +642,6 @@ export interface PsychicAppSpecialHooks {
   serverStart: ((server: PsychicServer) => void | Promise<void>)[]
   serverShutdown: ((server: PsychicServer) => void | Promise<void>)[]
   serverError: ((err: Error, req: Request, res: Response) => void | Promise<void>)[]
-  cliStart: ((program: Command) => void | Promise<void>)[]
 }
 
 export interface PsychicAppOverrides {

--- a/src/psychic-app/types.ts
+++ b/src/psychic-app/types.ts
@@ -14,17 +14,10 @@ export type PsychicHookEventType =
   | 'server:start'
   | 'server:error'
   | 'server:shutdown'
-  | 'cli:start'
 
 export type PsychicHookLoadEventTypes = Exclude<
   PsychicHookEventType,
-  | 'server:error'
-  | 'server:init'
-  | 'server:init:after-routes'
-  | 'server:start'
-  | 'server:shutdown'
-  | 'sync'
-  | 'cli:start'
+  'server:error' | 'server:init' | 'server:init:after-routes' | 'server:start' | 'server:shutdown' | 'sync'
 >
 
 export type PsychicAppInitializerCb = (psychicApp: PsychicApp) => void | Promise<void>

--- a/test-app/src/cli/index.ts
+++ b/test-app/src/cli/index.ts
@@ -14,15 +14,9 @@ import initializePsychicApp from './helpers/initializePsychicApp.js'
 
 const program = new Command()
 
-async function buildProgram() {
-  await initializePsychicApp()
+PsychicCLI.provide(program, {
+  initializePsychicApp,
+  seedDb,
+})
 
-  await PsychicCLI.provide(program, {
-    initializePsychicApp,
-    seedDb,
-  })
-
-  program.parse(process.argv)
-}
-
-void buildProgram()
+program.parse(process.argv)

--- a/test-app/src/conf/initializers/initializerOne.ts
+++ b/test-app/src/conf/initializers/initializerOne.ts
@@ -1,13 +1,1 @@
-import { PsychicApp } from '../../../../src/index.js'
-
-export default (psy: PsychicApp) => {
-  psy.on('cli:start', program => {
-    program
-      .command('cli-start-hooks:test')
-      .description('tests that our custom cli hooks work')
-      .action(() => {
-        console.log('cli:start hooks fired')
-        process.exit()
-      })
-  })
-}
+export default () => {}


### PR DESCRIPTION
these don't work, since sometimes you are running a cli command, i.e. psy db:reset, which processes the app in an invalid state. calling initializePsychicApp during that time causes it to crash.