### PR TITLE
fix rendering bug when rendering an array of serializables

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "0.34.3",
+  "version": "0.34.4",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/spec/unit/openapi-renderer/endpoint/toSchemaObject.spec.ts
+++ b/spec/unit/openapi-renderer/endpoint/toSchemaObject.spec.ts
@@ -970,16 +970,13 @@ The following values will be allowed:
               properties: {
                 id: { type: 'integer' },
                 posts: {
-                  anyOf: [
-                    {
-                      type: 'array',
-                      items: { $ref: '#/components/schemas/PostSummary' },
-                    },
-                    {
-                      type: 'array',
-                      items: { $ref: '#/components/schemas/UserSummary' },
-                    },
-                  ],
+                  type: 'array',
+                  items: {
+                    anyOf: [
+                      { $ref: '#/components/schemas/PostSummary' },
+                      { $ref: '#/components/schemas/UserSummary' },
+                    ],
+                  },
                 },
               },
             },
@@ -1223,16 +1220,13 @@ The following values will be allowed:
                 properties: {
                   id: { type: 'integer' },
                   posts: {
-                    anyOf: [
-                      {
-                        type: 'array',
-                        items: { $ref: '#/components/schemas/PostSummary' },
-                      },
-                      {
-                        type: 'array',
-                        items: { $ref: '#/components/schemas/UserSummary' },
-                      },
-                    ],
+                    type: 'array',
+                    items: {
+                      anyOf: [
+                        { $ref: '#/components/schemas/PostSummary' },
+                        { $ref: '#/components/schemas/UserSummary' },
+                      ],
+                    },
                   },
                 },
               },

--- a/src/openapi-renderer/serializer.ts
+++ b/src/openapi-renderer/serializer.ts
@@ -397,22 +397,9 @@ Error: ${this.serializerClass.name} missing explicit serializer definition for $
           association.field,
         ])
 
-        switch (association.type) {
-          case 'RendersMany':
-            anyOf.push({
-              type: 'array',
-              items: {
-                $ref: `#/components/schemas/${associatedSerializerKey}`,
-              },
-            })
-            break
-
-          case 'RendersOne':
-            anyOf.push({
-              $ref: `#/components/schemas/${associatedSerializerKey}`,
-            })
-            break
-        }
+        anyOf.push({
+          $ref: `#/components/schemas/${associatedSerializerKey}`,
+        })
 
         const associatedSchema = new OpenapiSerializerRenderer({
           openapiName: this.openapiName,
@@ -427,9 +414,21 @@ Error: ${this.serializerClass.name} missing explicit serializer definition for $
         finalOutput = { ...finalOutput, ...associatedSchema }
       })
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-      ;(finalOutput as any)[serializerKey].properties![association.field] = {
-        anyOf,
+      switch (association.type) {
+        case 'RendersMany':
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+          ;(finalOutput as any)[serializerKey].properties![association.field] = {
+            type: 'array',
+            items: { anyOf },
+          }
+          break
+
+        case 'RendersOne':
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+          ;(finalOutput as any)[serializerKey].properties![association.field] = {
+            anyOf,
+          }
+          break
       }
     }
 


### PR DESCRIPTION
when rendering an array of serializables, it should be an array where all the possible serializables are anyOf'd together, to express a single array with many possible items.

close https://rvohealth.atlassian.net/browse/PDTC-7761