### PR TITLE
add paginate option to OpenAPI decorator

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2228,6 +2228,84 @@
         }
       }
     },
+    "/users/paginated": {
+      "parameters": [
+        {
+          "in": "header",
+          "name": "custom-header",
+          "required": true,
+          "description": "custom header",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "recordCount",
+                    "pageCount",
+                    "currentPage",
+                    "results"
+                  ],
+                  "properties": {
+                    "recordCount": {
+                      "type": "number"
+                    },
+                    "pageCount": {
+                      "type": "number"
+                    },
+                    "currentPage": {
+                      "type": "number"
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/UserSummary"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "418": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationErrors"
+          },
+          "490": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
     "/users/{id}": {
       "parameters": [
         {
@@ -3076,6 +3154,17 @@
             "items": {
               "type": "string"
             }
+          }
+        }
+      },
+      "UserSummary": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer"
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "0.34.4",
+  "version": "0.34.5",
   "author": "RVOHealth",
   "repository": {
     "type": "git",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@eslint/js": "^9.19.0",
     "@jest-mock/express": "^3.0.0",
-    "@rvoh/dream": "^0.42.0",
+    "@rvoh/dream": "^0.42.3",
     "@rvoh/dream-spec-helpers": "^0.2.4",
     "@rvoh/psychic-spec-helpers": "^0.6.0",
     "@types/express": "^5.0.1",

--- a/spec/unit/openapi-renderer/endpoint/toPathObject.spec.ts
+++ b/spec/unit/openapi-renderer/endpoint/toPathObject.spec.ts
@@ -1927,6 +1927,66 @@ The following values will be allowed:
         })
       })
 
+      context('with paginate=true', () => {
+        const expectedPagination = {
+          200: {
+            description: 'Success',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['recordCount', 'pageCount', 'currentPage', 'results'],
+                  properties: {
+                    recordCount: {
+                      type: 'number',
+                    },
+                    pageCount: {
+                      type: 'number',
+                    },
+                    currentPage: {
+                      type: 'number',
+                    },
+                    results: {
+                      type: 'array',
+                      items: {
+                        $ref: '#/components/schemas/UserExtra',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }
+
+        it('captures results into an array and includes pagination fields in response shape', () => {
+          const renderer = new OpenapiEndpointRenderer(User, UsersController, 'howyadoin', {
+            serializerKey: 'extra',
+            paginate: true,
+          })
+
+          const response = renderer.toPathObject('default', {}, routes)
+          expect(response['/users/howyadoin']!.get.responses).toEqual(
+            expect.objectContaining(expectedPagination),
+          )
+        })
+
+        context('when many is also passed', () => {
+          it('paginate correctly overrides many option', () => {
+            const renderer = new OpenapiEndpointRenderer(User, UsersController, 'howyadoin', {
+              serializerKey: 'extra',
+              many: true,
+              paginate: true,
+            })
+
+            const response = renderer.toPathObject('default', {}, routes)
+            expect(response['/users/howyadoin']!.get.responses).toEqual(
+              expect.objectContaining(expectedPagination),
+            )
+          })
+        })
+      })
+
       context('with extra response fields sent', () => {
         it('includes extra response payloads', () => {
           const renderer = new OpenapiEndpointRenderer(User, UsersController, 'howyadoin', {

--- a/spec/unit/scenarios/pagination.spec.ts
+++ b/spec/unit/scenarios/pagination.spec.ts
@@ -1,0 +1,21 @@
+import { specRequest as request } from '@rvoh/psychic-spec-helpers'
+import PsychicServer from '../../../src/server/index.js'
+import User from '../../../test-app/src/app/models/User.js'
+
+describe('when using a controller that implements pagination', () => {
+  beforeEach(async () => {
+    await request.init(PsychicServer)
+  })
+
+  it('correctly paginates results', async () => {
+    const user = await User.create({ email: 'how@yadoin', password: 'howyadoin', name: 'fredo' })
+    const results = await request.get('/users/paginated', 200)
+
+    expect(results.body).toEqual({
+      recordCount: 1,
+      pageCount: 1,
+      currentPage: 1,
+      results: [{ id: user.id }],
+    })
+  })
+})

--- a/src/controller/helpers/isPaginatedResult.ts
+++ b/src/controller/helpers/isPaginatedResult.ts
@@ -1,0 +1,16 @@
+import { isObject } from '../../helpers/typechecks.js'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function isPaginatedResult(result: any) {
+  if (!isObject(result)) return false
+
+  const paginatedFields = ['currentPage', 'pageCount', 'recordCount', 'results']
+  const keys = Object.keys(result as object)
+  if (keys.length !== paginatedFields.length) return false
+
+  for (const paginatedField of paginatedFields) {
+    if (!keys.includes(paginatedField)) return false
+  }
+
+  return true
+}

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -42,6 +42,7 @@ import Params, {
 } from '../server/params.js'
 import Session, { CustomSessionCookieOptions } from '../session/index.js'
 import ParamValidationError from '../error/controller/ParamValidationError.js'
+import isPaginatedResult from './helpers/isPaginatedResult.js'
 
 type SerializerResult = {
   [key: string]: // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -392,6 +393,13 @@ The key in question is: "${serializerKey}"`,
           this.singleObjectJson(d, opts),
         ),
       )
+
+    if (isPaginatedResult(data))
+      return this.res.json({
+        ...data,
+        results: (data as { results: unknown[] }).results.map(result => this.singleObjectJson(result, opts)),
+      })
+
     return this.res.json(this.singleObjectJson(data, opts))
   }
 

--- a/test-app/src/app/controllers/UsersController.ts
+++ b/test-app/src/app/controllers/UsersController.ts
@@ -61,6 +61,18 @@ export default class UsersController extends ApplicationController {
 
   @OpenAPI(User, {
     status: 200,
+    paginate: true,
+    serializerKey: 'summary',
+  })
+  public async paginated() {
+    const users = await User.order('createdAt').paginate({
+      page: this.castParam('page', 'integer', { allowNull: true }),
+    })
+    this.ok(users)
+  }
+
+  @OpenAPI(User, {
+    status: 200,
     serializerKey: 'withPosts',
   })
   public async show() {

--- a/test-app/src/conf/routes.ts
+++ b/test-app/src/conf/routes.ts
@@ -45,6 +45,9 @@ export default (r: PsychicRouter) => {
   r.get('openapi/openapi-overrides', OpenapiOverridesTestController, 'testOpenapiConfigOverrides')
 
   r.resources('users', r => {
+    r.collection(r => {
+      r.get('paginated', UsersController, 'paginated')
+    })
     r.resources('pets', { only: [] })
     r.get('ping', UsersController, 'ping')
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -841,9 +841,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rvoh/dream@npm:^0.42.0":
-  version: 0.42.0
-  resolution: "@rvoh/dream@npm:0.42.0"
+"@rvoh/dream@npm:^0.42.3":
+  version: 0.42.3
+  resolution: "@rvoh/dream@npm:0.42.3"
   dependencies:
     colorette: "npm:^2.0.20"
     commander: "npm:^12.1.0"
@@ -858,7 +858,7 @@ __metadata:
     kysely: ^0.27.4
     kysely-codegen: ~0.17.0
     pg: "*"
-  checksum: 10c0/7d40ba9134ebe732bdb4ab17f7e6aa056c5fb8e89be56def0d061d920274b57d1b3e95ba2f7fe0b35373992cd5fbc3efb1e78d3c70dec36d331e0ff52789b61d
+  checksum: 10c0/da9a77b89851d10b4058fbf82a6330ca8006c8661b7649b96b5a49dcfb2b284f3f5ed92f69403db3c4da737a09cc964a094194161bda1a3700807a8227c30611
   languageName: node
   linkType: hard
 
@@ -883,7 +883,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.19.0"
     "@jest-mock/express": "npm:^3.0.0"
-    "@rvoh/dream": "npm:^0.42.0"
+    "@rvoh/dream": "npm:^0.42.3"
     "@rvoh/dream-spec-helpers": "npm:^0.2.4"
     "@rvoh/psychic-spec-helpers": "npm:^0.6.0"
     "@types/cookie-parser": "npm:^1.4.8"


### PR DESCRIPTION
this paginate option will enable devs to easily specify the output shape for their endpoint as the exact shape matching a pagination result from Dream