### PR TITLE
Add `--owning-model` option to resource generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/spec/unit/generate/helpers/generateResourceControllerSpecContent.spec.ts
+++ b/spec/unit/generate/helpers/generateResourceControllerSpecContent.spec.ts
@@ -362,14 +362,14 @@ describe('V1/Host/LocalizedTextsController', () => {
     })
   })
 
-  context('when resourceAttachedTo is specified', () => {
+  context('when owningModel is specified', () => {
     it('generates specs with both user and attached model', () => {
       const res = generateResourceControllerSpecContent({
         fullyQualifiedControllerName: 'V1/Host/ReviewsController',
         route: 'v1/host/reviews',
         fullyQualifiedModelName: 'Review',
         columnsWithTypes: ['content:text', 'rating:integer'],
-        resourceAttachedTo: 'Host',
+        owningModel: 'Host',
       })
       expect(res).toContain('let user: User')
       expect(res).toContain('let host: Host')

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -22,7 +22,7 @@ export default class PsychicBin {
     route: string,
     fullyQualifiedModelName: string,
     columnsWithTypes: string[],
-    options: { stiBaseSerializer: boolean; resourceAttachedTo?: string },
+    options: { stiBaseSerializer: boolean; owningModel?: string },
   ) {
     await generateResource({ route, fullyQualifiedModelName, columnsWithTypes, options })
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,11 +31,11 @@ export default class PsychicCLI {
       .description('create a Dream model, migration, controller, serializer, and spec placeholders')
       .option(
         '--sti-base-serializer',
-        'Omits the serializer from the dream model, but does create the serializer so it can be extended by STI children',
+        'omits the serializer from the dream model, but does create the serializer so it can be extended by STI children',
       )
       .option(
-        '--resource-attached-to <modelName>',
-        'Specify a model that the resource is attached to (e.g., "Host", "Guest") for scoping resources',
+        '--owning-model <modelName>',
+        'The model class of the object that `associationQuery`/`createAssociation` will be performed on in the created controller and spec (e.g., "Host", "Guest") (simply to save time making changes to the generated code). Defaults to User',
       )
       .argument('<path>', 'URL path from root domain')
       .argument(
@@ -51,7 +51,7 @@ export default class PsychicCLI {
           route: string,
           modelName: string,
           columnsWithTypes: string[],
-          options: { stiBaseSerializer: boolean; resourceAttachedTo?: string },
+          options: { stiBaseSerializer: boolean; owningModel?: string },
         ) => {
           await initializePsychicApp()
           await PsychicBin.generateResource(route, modelName, columnsWithTypes, options)

--- a/src/generate/controller.ts
+++ b/src/generate/controller.ts
@@ -15,14 +15,14 @@ export default async function generateController({
   actions,
   columnsWithTypes = [],
   resourceSpecs = false,
-  resourceAttachedTo,
+  owningModel,
 }: {
   fullyQualifiedControllerName: string
   fullyQualifiedModelName?: string
   actions: string[]
   columnsWithTypes?: string[]
   resourceSpecs?: boolean
-  resourceAttachedTo?: string | undefined
+  owningModel?: string | undefined
 }) {
   fullyQualifiedModelName = fullyQualifiedModelName
     ? standardizeFullyQualifiedModelName(fullyQualifiedModelName)
@@ -99,7 +99,7 @@ export default async function generateController({
         fullyQualifiedControllerName,
         fullyQualifiedModelName,
         actions,
-        resourceAttachedTo,
+        owningModel,
       }),
     )
   } catch (error) {
@@ -118,7 +118,7 @@ export default async function generateController({
     fullyQualifiedModelName,
     columnsWithTypes,
     resourceSpecs,
-    resourceAttachedTo,
+    owningModel,
   })
 }
 
@@ -142,14 +142,14 @@ async function generateControllerSpec({
   fullyQualifiedModelName,
   columnsWithTypes,
   resourceSpecs,
-  resourceAttachedTo,
+  owningModel,
 }: {
   fullyQualifiedControllerName: string
   route: string
   fullyQualifiedModelName: string | undefined
   columnsWithTypes: string[]
   resourceSpecs: boolean
-  resourceAttachedTo: string | undefined
+  owningModel: string | undefined
 }) {
   const { relFilePath, absDirPath, absFilePath } = psychicFileAndDirPaths(
     psychicPath('controllerSpecs'),
@@ -167,7 +167,7 @@ async function generateControllerSpec({
             route,
             fullyQualifiedModelName,
             columnsWithTypes,
-            resourceAttachedTo,
+            owningModel,
           })
         : generateControllerSpecContent(fullyQualifiedControllerName), //, route, fullyQualifiedModelName, actions),
     )

--- a/src/generate/helpers/generateResourceControllerSpecContent.ts
+++ b/src/generate/helpers/generateResourceControllerSpecContent.ts
@@ -12,26 +12,24 @@ export default function generateResourceControllerSpecContent({
   route,
   fullyQualifiedModelName,
   columnsWithTypes,
-  resourceAttachedTo,
+  owningModel,
 }: {
   fullyQualifiedControllerName: string
   route: string
   fullyQualifiedModelName: string
   columnsWithTypes: string[]
-  resourceAttachedTo?: string | undefined
+  owningModel?: string | undefined
 }) {
   fullyQualifiedModelName = standardizeFullyQualifiedModelName(fullyQualifiedModelName)
   const modelClassName = globalClassNameFromFullyQualifiedModelName(fullyQualifiedModelName)
   const modelVariableName = camelize(modelClassName)
 
   // Always use User for authentication
-  const userModelClassName = 'User'
+  const owningModelClassName = 'User'
   const userVariableName = 'user'
 
   // Determine attached model settings if provided
-  const attachedModelClassName = resourceAttachedTo
-    ? globalClassNameFromFullyQualifiedModelName(resourceAttachedTo)
-    : null
+  const attachedModelClassName = owningModel ? globalClassNameFromFullyQualifiedModelName(owningModel) : null
   const attachedModelVariableName = attachedModelClassName ? camelize(attachedModelClassName) : null
 
   const importStatements: string[] = [
@@ -42,10 +40,10 @@ export default function generateResourceControllerSpecContent({
   ]
 
   // Add attached model imports if specified
-  if (resourceAttachedTo) {
+  if (owningModel) {
     importStatements.push(
-      importStatementForModel(fullyQualifiedControllerName, resourceAttachedTo),
-      importStatementForModelFactory(fullyQualifiedControllerName, resourceAttachedTo),
+      importStatementForModel(fullyQualifiedControllerName, owningModel),
+      importStatementForModelFactory(fullyQualifiedControllerName, owningModel),
     )
   }
 
@@ -86,7 +84,7 @@ import { specRequest as request } from '@rvoh/psychic-spec-helpers'${uniq(import
 import addEndUserAuthHeader from '${specUnitUpdirs}helpers/authentication.js'
 
 describe('${fullyQualifiedControllerName}', () => {
-  let ${userVariableName}: ${userModelClassName}${attachedModelVariableName ? `\n  let ${attachedModelVariableName}: ${attachedModelClassName}` : ''}
+  let ${userVariableName}: ${owningModelClassName}${attachedModelVariableName ? `\n  let ${attachedModelVariableName}: ${attachedModelClassName}` : ''}
 
   beforeEach(async () => {
     await request.init(PsychicServer)
@@ -113,7 +111,7 @@ describe('${fullyQualifiedControllerName}', () => {
       ])
     })
 
-    context('${modelClassName}s created by another ${userModelClassName}', () => {
+    context('${modelClassName}s created by another ${owningModelClassName}', () => {
       it('are omitted', async () => {
         await create${modelClassName}()
         const results = (await subject()).body
@@ -143,10 +141,10 @@ describe('${fullyQualifiedControllerName}', () => {
       )
     })
 
-    context('${fullyQualifiedModelName} created by another ${userModelClassName}', () => {
+    context('${fullyQualifiedModelName} created by another ${owningModelClassName}', () => {
       it('is not found', async () => {
-        const other${userModelClassName}${modelClassName} = await create${modelClassName}()
-        await subject(other${userModelClassName}${modelClassName}, 404)
+        const other${owningModelClassName}${modelClassName} = await create${modelClassName}()
+        await subject(other${owningModelClassName}${modelClassName}, 404)
       })
     })
   })
@@ -159,7 +157,7 @@ describe('${fullyQualifiedControllerName}', () => {
       })
     }
 
-    it('creates a ${fullyQualifiedModelName} for this ${userModelClassName}', async () => {
+    it('creates a ${fullyQualifiedModelName} for this ${owningModelClassName}', async () => {
       const results = (await subject({
         ${originalStringKeyValues.length ? originalStringKeyValues.join('\n        ') : ''}
       })).body
@@ -193,7 +191,7 @@ describe('${fullyQualifiedControllerName}', () => {
       ${updatedStringAttributeChecks.join('\n      ')}
     })
 
-    context('a ${fullyQualifiedModelName} created by another ${userModelClassName}', () => {
+    context('a ${fullyQualifiedModelName} created by another ${owningModelClassName}', () => {
       it('is not updated', async () => {
         const ${modelVariableName} = await create${modelClassName}()
         await subject(${modelVariableName}, {
@@ -220,7 +218,7 @@ describe('${fullyQualifiedControllerName}', () => {
       expect(await ${modelClassName}.find(${modelVariableName}.id)).toBeNull()
     })
 
-    context('a ${fullyQualifiedModelName} created by another ${userModelClassName}', () => {
+    context('a ${fullyQualifiedModelName} created by another ${owningModelClassName}', () => {
       it('is not deleted', async () => {
         const ${modelVariableName} = await create${modelClassName}()
         await subject(${modelVariableName}, 404)

--- a/src/generate/resource.ts
+++ b/src/generate/resource.ts
@@ -11,7 +11,7 @@ export default async function generateResource({
 }: {
   route: string
   fullyQualifiedModelName: string
-  options: { stiBaseSerializer: boolean; resourceAttachedTo?: string }
+  options: { stiBaseSerializer: boolean; owningModel?: string }
   columnsWithTypes: string[]
 }) {
   await generateDream({
@@ -28,7 +28,7 @@ export default async function generateResource({
     actions: ['create', 'index', 'show', 'update', 'destroy'],
     columnsWithTypes,
     resourceSpecs: true,
-    resourceAttachedTo: options.resourceAttachedTo,
+    owningModel: options.owningModel,
   })
 
   await addResourceToRoutes(route)


### PR DESCRIPTION
The model class of the object that `associationQuery`/`createAssociation` will be performed on in the created controller and spec (e.g., "Host", "Guest") (simply to save time making changes to the generated code). Defaults to User