### PR TITLE
new including arg for paramsFor, openapi paramsFor

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "0.37.5",
+  "version": "0.37.6",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/spec/unit/server/params.spec.ts
+++ b/spec/unit/server/params.spec.ts
@@ -100,6 +100,18 @@ describe('Params', () => {
       })
     })
 
+    context('with including option passed', () => {
+      it('allows unsafe attributes when explicitly provided through the "including" option', () => {
+        const params = Params.for({ species: 'cat', userId: '1', id: '123' }, Pet, {
+          including: ['userId'],
+        })
+
+        // userId is of type integer at the db level, so we should
+        // expect integer coercion here.
+        expect(params).toEqual({ species: 'cat', userId: 1 })
+      })
+    })
+
     context('enum', () => {
       it('permits values inside the enum', () => {
         expect(Params.for({ species: 'cat' }, Pet)).toEqual({ species: 'cat' })

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -1,5 +1,6 @@
 import {
   Dream,
+  DreamAttributes,
   DreamModelSerializerType,
   DreamParamSafeAttributes,
   DreamSerializerBuilder,
@@ -49,6 +50,7 @@ import OpenapiEndpointRenderer from '../openapi-renderer/endpoint.js'
 import PsychicApp from '../psychic-app/index.js'
 import Params, {
   ParamsCastOptions,
+  ParamsForDreamClass,
   ParamsForOpts,
   ValidatedAllowsNull,
   ValidatedReturnType,
@@ -145,7 +147,7 @@ export default class PsychicController {
    * by using the `@Openapi` decorator on your controller methods
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public static openapi: Record<string, OpenapiEndpointRenderer<any>>
+  public static openapi: Record<string, OpenapiEndpointRenderer<any, any>>
 
   /**
    * Enables you to specify specific serializers to use
@@ -331,12 +333,16 @@ export default class PsychicController {
   }
 
   public paramsFor<
-    DreamClass extends typeof Dream,
-    const OnlyArray extends readonly (keyof DreamParamSafeAttributes<InstanceType<DreamClass>>)[],
-    ForOpts extends ParamsForOpts<OnlyArray> & {
-      key?: string
-    },
-  >(this: PsychicController, dreamClass: DreamClass, opts?: ForOpts) {
+    T extends typeof Dream,
+    I extends InstanceType<T>,
+    const OnlyArray extends readonly (keyof DreamParamSafeAttributes<I>)[],
+    const IncludingArray extends Exclude<keyof DreamAttributes<I>, OnlyArray[number]>[],
+    ReturnPayload = ParamsForDreamClass<T, OnlyArray, IncludingArray>,
+    ForOpts extends ParamsForOpts<OnlyArray, IncludingArray> & { key?: string } = ParamsForOpts<
+      OnlyArray,
+      IncludingArray
+    > & { key?: string },
+  >(this: PsychicController, dreamClass: T, opts?: ForOpts): ReturnPayload {
     return Params.for(
       opts?.key ? (this.params[opts.key] as typeof this.params) || {} : this.params,
       dreamClass,

--- a/src/openapi-renderer/helpers/dreamColumnToOpenapiType.ts
+++ b/src/openapi-renderer/helpers/dreamColumnToOpenapiType.ts
@@ -1,0 +1,143 @@
+import { Dream, OpenapiSchemaBody } from '@rvoh/dream'
+import primitiveOpenapiStatementToOpenapi from './primitiveOpenapiStatementToOpenapi.js'
+import OpenapiSegmentExpander from '../body-segment.js'
+
+export default function dreamColumnToOpenapiType(
+  dreamClass: typeof Dream,
+  columnName: string,
+): Record<string, OpenapiSchemaBody> {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const schema = dreamClass.prototype.schema
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const columns = schema[dreamClass.prototype.table]?.columns as object
+
+  const columnMetadata = columns[columnName as keyof typeof columns] as {
+    dbType: string
+    allowNull: boolean
+    isArray: boolean
+    enumValues: unknown[] | null
+  }
+
+  const nullableColumn = columnMetadata?.allowNull
+
+  switch (columnMetadata?.dbType) {
+    case 'boolean':
+    case 'boolean[]':
+    case 'date':
+    case 'date[]':
+    case 'integer':
+    case 'integer[]':
+      return {
+        [columnName]: primitiveOpenapiStatementToOpenapi(columnMetadata.dbType, nullableColumn),
+      }
+
+    case 'character varying':
+    case 'citext':
+    case 'text':
+    case 'uuid':
+    case 'bigint':
+      return {
+        [columnName]: primitiveOpenapiStatementToOpenapi('string', nullableColumn),
+      }
+
+    case 'character varying[]':
+    case 'citext[]':
+    case 'text[]':
+    case 'uuid[]':
+    case 'bigint[]':
+      return {
+        [columnName]: primitiveOpenapiStatementToOpenapi('string[]', nullableColumn),
+      }
+
+    case 'timestamp':
+    case 'timestamp with time zone':
+    case 'timestamp without time zone':
+      return {
+        [columnName]: primitiveOpenapiStatementToOpenapi('date-time', nullableColumn),
+      }
+
+    case 'timestamp[]':
+    case 'timestamp with time zone[]':
+    case 'timestamp without time zone[]':
+      return {
+        [columnName]: primitiveOpenapiStatementToOpenapi('date-time[]', nullableColumn),
+      }
+
+    case 'json':
+    case 'jsonb':
+      return {
+        [columnName]: {
+          type: nullableColumn ? ['object', 'null'] : 'object',
+        },
+      }
+
+    case 'json[]':
+    case 'jsonb[]':
+      return {
+        [columnName]: {
+          type: nullableColumn ? ['array', 'null'] : 'array',
+          items: {
+            type: 'object',
+          },
+        },
+      }
+
+    case 'numeric':
+      return {
+        [columnName]: primitiveOpenapiStatementToOpenapi('number', nullableColumn),
+      }
+
+    case 'numeric[]':
+      return {
+        [columnName]: primitiveOpenapiStatementToOpenapi('number[]', nullableColumn),
+      }
+
+    default:
+      if (dreamClass.isVirtualColumn(columnName)) {
+        const metadata = dreamClass['virtualAttributes'].find(statement => statement.property === columnName)
+        if (metadata?.type) {
+          return {
+            [columnName]: new OpenapiSegmentExpander(metadata.type, {
+              renderOpts: {
+                casing: 'camel',
+                suppressResponseEnums: false,
+              },
+              target: 'request',
+            }).render().openapi,
+          }
+        } else {
+          return {
+            [columnName]: {
+              anyOf: [
+                { type: ['string', 'null'] },
+                { type: ['number', 'null'] },
+                { type: ['object', 'null'] },
+              ],
+            },
+          }
+        }
+      } else if (columnMetadata?.enumValues) {
+        if (columnMetadata.isArray) {
+          return {
+            [columnName]: {
+              type: nullableColumn ? ['array', 'null'] : 'array',
+              items: {
+                type: 'string',
+                enum: [...columnMetadata.enumValues, ...(nullableColumn ? [null] : [])],
+              },
+            } as OpenapiSchemaBody,
+          }
+        } else {
+          return {
+            [columnName]: {
+              type: nullableColumn ? ['string', 'null'] : 'string',
+              enum: [...columnMetadata.enumValues, ...(nullableColumn ? [null] : [])],
+            } as OpenapiSchemaBody,
+          }
+        }
+      }
+
+      return {}
+  }
+}

--- a/src/server/helpers/paramNamesForDreamClass.ts
+++ b/src/server/helpers/paramNamesForDreamClass.ts
@@ -1,0 +1,58 @@
+import { Dream, DreamAttributes, DreamParamSafeAttributes, DreamParamSafeColumnNames } from '@rvoh/dream'
+import { ParamExclusionOptions } from '../params.js'
+
+export default function paramNamesForDreamClass<
+  T extends typeof Dream,
+  I extends InstanceType<T>,
+  const OnlyArray extends readonly (keyof DreamParamSafeAttributes<I>)[],
+  const IncludingArray extends Exclude<keyof DreamAttributes<I>, OnlyArray[number]>[],
+  ForOpts extends ParamExclusionOptions<OnlyArray, IncludingArray>,
+  ParamSafeColumnsOverride extends I['paramSafeColumns' & keyof I] extends never
+    ? undefined
+    : I['paramSafeColumns' & keyof I] & string[],
+  ParamSafeColumns extends ParamSafeColumnsOverride extends string[] | Readonly<string[]>
+    ? Extract<DreamParamSafeColumnNames<I>, ParamSafeColumnsOverride[number] & DreamParamSafeColumnNames<I>>[]
+    : DreamParamSafeColumnNames<I>[],
+  ReturnPartialWithOnly extends ForOpts['only'] extends readonly (keyof DreamParamSafeAttributes<
+    InstanceType<T>
+  >)[]
+    ? Partial<{
+        [K in Extract<
+          ParamSafeColumns[number],
+          ForOpts['only'][number & keyof ForOpts['only']]
+        >]: DreamParamSafeAttributes<InstanceType<T>>[K]
+      }>
+    : Partial<{
+        [K in ParamSafeColumns[number & keyof ParamSafeColumns] & string]: DreamParamSafeAttributes<
+          InstanceType<T>
+        >[K & keyof DreamParamSafeAttributes<InstanceType<T>>]
+      }>,
+  ReturnPartialWithIncluding extends ForOpts['including'] extends readonly (keyof DreamAttributes<
+    InstanceType<T>
+  >)[]
+    ? ReturnPartialWithOnly &
+        Partial<{
+          [K in Extract<
+            keyof DreamAttributes<InstanceType<T>>,
+            ForOpts['including'][number & keyof ForOpts['including']]
+          >]: DreamAttributes<InstanceType<T>>[K]
+        }>
+    : ReturnPartialWithOnly,
+  RetArray = (keyof ReturnPartialWithIncluding)[],
+>(dreamClass: T, { only, including }: ForOpts = {} as ForOpts): RetArray {
+  let paramSafeColumns: RetArray = Array.isArray(only)
+    ? ((dreamClass.paramSafeColumnsOrFallback() as string[]).filter(column =>
+        only.includes(column as (typeof only)[number]),
+      ) as unknown as RetArray)
+    : (dreamClass.paramSafeColumnsOrFallback() as string[] as RetArray)
+
+  if (Array.isArray(including)) {
+    paramSafeColumns = [
+      ...(paramSafeColumns as string[]),
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
+      ...[...dreamClass.columns()].filter(columnName => including.includes(columnName as any)),
+    ] as RetArray
+  }
+
+  return paramSafeColumns
+}


### PR DESCRIPTION
* enable paramsFor to include unsafe params
* add OpenAPI.paramsFor, which enables a user to specify custom params for a model at the openapi level.

i.e.

```ts
@OpenAPI(User, {
  requestBody: { only: ['email'], including: ['id'] }
})
public async create() {
  await User.create(this.paramsFor(User, { only: ['email'], including: ['id'] }))
  this.created()
}
```

close https://rvohealth.atlassian.net/browse/PDTC-7977