### PR TITLE
add `use` method, add routing middleware support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+## v1.1.0
+
+Provides easier access to express middleware by exposing `PsychicApp#use`, which enables a developer to provide express middleware directly through the psychcic application, without tapping into any hooks.
+
+```ts
+psy.use((_, res) => {
+  res.send(
+    'this will be run after psychic middleware (i.e. cors and bodyParser) are processed, but before routes are processed',
+  )
+})
+```
+
+Some middleware needs to be run before other middleware, so we expose an optional first argument which can be provided so explicitly send your middleware into express at various stages of the psychic configuration process. For example, to inject your middleware before cors and bodyParser are configured, provide `before-middleware` as the first argument. To initialize your middleware after the psychic default middleware, but before your routes have been processed, provide `after-middleware` as the first argument (or simply provide a callback function directly, since this is the default). To run after routes have been processed, provide `after-routes` as the first argument.
+
+```ts
+psy.use('before-middleware', (_, res) => {
+  res.send('this will be run before psychic has configured any default middleware')
+})
+
+psy.use('after-middleware', (_, res) => {
+  res.send('this will be run after psychic has configured default middleware')
+})
+
+psy.use('after-routes', (_, res) => {
+  res.send('this will be run after psychic has processed all the routes in your conf/routes.ts file')
+})
+```
+
+Additionally, a new overload has been added to all CRUD methods on the PsychicRouter class, enabling you to provide RequestHandler middleware directly to psychic, like so:
+
+```ts
+// conf/routes.ts
+
+r.get('helloworld', (req, res, next) => {
+  res.json({ hello: 'world' })
+})
+```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/spec/unit/router/resource.spec.ts
+++ b/spec/unit/router/resource.spec.ts
@@ -3,6 +3,7 @@ import PsychicRouter from '../../../src/router/index.js'
 import PsychicServer from '../../../src/server/index.js'
 import PetsController from '../../../test-app/src/app/controllers/PetsController.js'
 import UsersController from '../../../test-app/src/app/controllers/UsersController.js'
+import { ControllerActionRouteConfig } from '../../../src/router/route-manager.js'
 
 describe('PsychicRouter', () => {
   beforeEach(async () => {
@@ -70,8 +71,9 @@ describe('PsychicRouter', () => {
         it('uses the passed controller instead of assuming', () => {
           router.resource('user', { only: ['update'], controller: PetsController })
           router.commit()
-          expect(router.routes[0]!.controller).toEqual(PetsController)
-          expect(router.routes[0]!.action).toEqual('update')
+          const route = router.routes[0]! as ControllerActionRouteConfig
+          expect(route.controller).toEqual(PetsController)
+          expect(route.action).toEqual('update')
         })
       })
 

--- a/spec/unit/router/resources.spec.ts
+++ b/spec/unit/router/resources.spec.ts
@@ -3,6 +3,7 @@ import PsychicRouter from '../../../src/router/index.js'
 import PsychicServer from '../../../src/server/index.js'
 import PetsController from '../../../test-app/src/app/controllers/PetsController.js'
 import UsersController from '../../../test-app/src/app/controllers/UsersController.js'
+import { ControllerActionRouteConfig } from '../../../src/router/route-manager.js'
 
 describe('PsychicRouter', () => {
   describe('resources', () => {
@@ -69,8 +70,9 @@ describe('PsychicRouter', () => {
         it('uses the passed controller instead of assuming', () => {
           router.resources('users', { only: ['create'], controller: PetsController })
           router.commit()
-          expect(router.routes[0]!.controller).toEqual(PetsController)
-          expect(router.routes[0]!.action).toEqual('create')
+          const route = router.routes[0]! as ControllerActionRouteConfig
+          expect(route.controller).toEqual(PetsController)
+          expect(route.action).toEqual('create')
         })
       })
 

--- a/spec/unit/server/hooks.spec.ts
+++ b/spec/unit/server/hooks.spec.ts
@@ -1,5 +1,5 @@
 import { PsychicServer } from '../../../src/index.js'
-import { PsychicHookEventType } from '../../../src/psychic-app/types.js'
+import { specRequest as request } from '@rvoh/psychic-spec-helpers'
 
 describe('PsychicServer hooks', () => {
   let server: PsychicServer
@@ -9,7 +9,7 @@ describe('PsychicServer hooks', () => {
     server = new PsychicServer()
   })
 
-  function expectHookCalled(hookEventType: PsychicHookEventType) {
+  function expectHookCalled(hookEventType: string) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     expect((process.env as any).__PSYCHIC_HOOKS_TEST_CACHE.split(',')).toEqual(
       expect.arrayContaining([hookEventType]),
@@ -21,6 +21,14 @@ describe('PsychicServer hooks', () => {
     expectHookCalled('server:init:before-middleware')
     expectHookCalled('server:init:after-middleware')
     expectHookCalled('server:init:after-routes')
+  })
+
+  it('processes hooks for "use"', async () => {
+    await request.init(PsychicServer)
+    await request.get('/ok', 200)
+    expectHookCalled('use')
+    expectHookCalled('use:before-middleware')
+    expectHookCalled('use:after-middleware')
   })
 
   it('processes hooks for server:start', async () => {

--- a/spec/unit/server/middleware.spec.ts
+++ b/spec/unit/server/middleware.spec.ts
@@ -1,0 +1,49 @@
+import { PsychicServer } from '../../../src/index.js'
+import { specRequest as request } from '@rvoh/psychic-spec-helpers'
+
+describe('PsychicServer hooks', () => {
+  beforeEach(async () => {
+    await request.init(PsychicServer)
+  })
+
+  context('GET', () => {
+    it('processes middleware', async () => {
+      const res = await request.get('/middleware-test', 200)
+      expect(res.body).toEqual('get middleware test')
+    })
+  })
+
+  context('POST', () => {
+    it('processes middleware', async () => {
+      const res = await request.post('/middleware-test', 200)
+      expect(res.body).toEqual('post middleware test')
+    })
+  })
+
+  context('PUT', () => {
+    it('processes middleware', async () => {
+      const res = await request.put('/middleware-test', 200)
+      expect(res.body).toEqual('put middleware test')
+    })
+  })
+
+  context('PATCH', () => {
+    it('processes middleware', async () => {
+      const res = await request.patch('/middleware-test', 200)
+      expect(res.body).toEqual('patch middleware test')
+    })
+  })
+
+  context('DELETE', () => {
+    it('processes middleware', async () => {
+      const res = await request.delete('/middleware-test', 200)
+      expect(res.body).toEqual('delete middleware test')
+    })
+  })
+
+  context('namespacing', () => {
+    it('processes namespaced middleware', async () => {
+      await request.get('/nested-middleware/middleware-test', 200)
+    })
+  })
+})

--- a/src/bin/helpers/printRoutes.ts
+++ b/src/bin/helpers/printRoutes.ts
@@ -1,5 +1,5 @@
 import colors from 'yoctocolors'
-import { RouteConfig } from '../../router/route-manager.js'
+import { ControllerActionRouteConfig, RouteConfig } from '../../router/route-manager.js'
 import PsychicServer from '../../server/index.js'
 
 export default async function printRoutes() {
@@ -25,13 +25,18 @@ export default async function printRoutes() {
 
 function buildExpressions(routes: RouteConfig[]): [string, string][] {
   return routes.map(route => {
+    const formattedPath = '/' + route.path.replace(/^\//, '')
     const method = route.httpMethod.toUpperCase()
     const numMethodSpaces = 8 - method.length
 
     const beginningOfExpression = `${route.httpMethod.toUpperCase()}${' '.repeat(numMethodSpaces)}${
-      route.path
+      formattedPath
     }`
-    const endOfExpression = route.controller.disaplayName + '#' + route.action
+
+    const controllerRouteConf = route as ControllerActionRouteConfig
+    const endOfExpression = controllerRouteConf.controller
+      ? controllerRouteConf.controller.controllerActionPath(formattedPath)
+      : 'middleware'
 
     return [beginningOfExpression, endOfExpression]
   })
@@ -61,5 +66,5 @@ function calculateNumSpacesInLastGap(expressions: [string, string][]) {
     if (expression.length > desiredSpaceCount) desiredSpaceCount = expression.length
   })
 
-  return desiredSpaceCount + 3
+  return desiredSpaceCount
 }

--- a/src/openapi-renderer/endpoint.ts
+++ b/src/openapi-renderer/endpoint.ts
@@ -34,7 +34,7 @@ import NonSerializerDerivedInOpenapiEndpointRenderer from '../error/openapi/NonS
 import NonSerializerDerivedInToSchemaObjects from '../error/openapi/NonSerializerDerivedInToSchemaObjects.js'
 import OpenApiSerializerForEndpointNotAFunction from '../error/openapi/SerializerForEndpointNotAFunction.js'
 import { DreamOrViewModelClassSerializerArrayKeys } from '../helpers/typeHelpers.js'
-import { RouteConfig } from '../router/route-manager.js'
+import { ControllerActionRouteConfig, RouteConfig } from '../router/route-manager.js'
 import { HttpMethod } from '../router/types.js'
 import OpenapiSegmentExpander, {
   OpenapiBodySegment,
@@ -355,9 +355,12 @@ export default class OpenapiEndpointRenderer<
   private getCurrentRouteConfig(routes: RouteConfig[]) {
     // if the action is update, we want to specifically find the 'patch' route,
     // otherwise we find any route that matches
-    const filteredRoutes = routes.filter(
-      routeConfig => routeConfig.controller === this.controllerClass && routeConfig.action === this.action,
-    )
+    const filteredRoutes = routes.filter(routeConfig => {
+      const controllerRouteConf = routeConfig as ControllerActionRouteConfig
+      return (
+        controllerRouteConf.controller === this.controllerClass && controllerRouteConf.action === this.action
+      )
+    })
 
     const route =
       this.action === 'update'

--- a/src/psychic-app/index.ts
+++ b/src/psychic-app/index.ts
@@ -11,7 +11,7 @@ import {
 import * as bodyParser from 'body-parser'
 import { Command } from 'commander'
 import { CorsOptions } from 'cors'
-import { Application, Request, Response, Express, RequestHandler } from 'express'
+import { Request, RequestHandler, Response } from 'express'
 import * as http from 'node:http'
 import PackageManager from '../cli/helpers/PackageManager.js'
 import PsychicAppInitMissingApiRoot from '../error/psychic-app/init-missing-api-root.js'
@@ -36,7 +36,7 @@ import importControllers, { getControllersOrFail } from './helpers/import/import
 import importInitializers, { getInitializersOrBlank } from './helpers/import/importInitializers.js'
 import importServices, { getServicesOrFail } from './helpers/import/importServices.js'
 import lookupClassByGlobalName from './helpers/lookupClassByGlobalName.js'
-import { PsychicHookEventType, PsychicUseEventType, PsychicUseEventTypeValues } from './types.js'
+import { PsychicHookEventType, PsychicUseEventType } from './types.js'
 
 export default class PsychicApp {
   public static async init(
@@ -351,8 +351,8 @@ Try setting it to something valid, like:
     this.booted = true
   }
 
-  public use(on: PsychicUseEventType, handler: RequestHandler<any, any, any, any, any>): void
-  public use(handler: RequestHandler<any, any, any, any, any>): void
+  public use(on: PsychicUseEventType, handler: RequestHandler): void
+  public use(handler: RequestHandler): void
   public use(handler: () => void): void
   public use(pathOrOnOrHandler: unknown, maybeHandler?: unknown): void {
     if (maybeHandler) {
@@ -375,12 +375,12 @@ Try setting it to something valid, like:
           this.on('server:init:after-routes', wrappedHandler)
           break
         default:
-          throw new Error(`missing required case handler for PsychicApp#use: "${eventType}"`)
+          throw new Error(`missing required case handler for PsychicApp#use: "${eventType as string}"`)
       }
       return
     } else {
       const wrappedHandler = (server: PsychicServer) => {
-        server.expressApp.use(pathOrOnOrHandler as RequestHandler<any, any, any, any, any>)
+        server.expressApp.use(pathOrOnOrHandler as RequestHandler)
       }
       this.on('server:init:after-middleware', wrappedHandler)
     }

--- a/src/psychic-app/types.ts
+++ b/src/psychic-app/types.ts
@@ -13,5 +13,8 @@ export type PsychicHookEventType =
 
 export type PsychicAppInitializerCb = (psychicApp: PsychicApp) => void | Promise<void>
 
+export const PsychicUseEventTypeValues = ['before-middleware', 'after-middleware', 'after-routes'] as const
+export type PsychicUseEventType = (typeof PsychicUseEventTypeValues)[number]
+
 type Only<T, U> = T & Partial<Record<Exclude<keyof U, keyof T>, never>>
 export type Either<T, U> = Only<T, U> | Only<U, T>

--- a/src/router/route-manager.ts
+++ b/src/router/route-manager.ts
@@ -1,3 +1,4 @@
+import { RequestHandler } from 'express'
 import PsychicController from '../controller/index.js'
 import { HttpMethod } from './types.js'
 
@@ -22,11 +23,36 @@ export default class RouteManager {
       action,
     })
   }
+
+  public addMiddleware({
+    httpMethod,
+    path,
+    middleware,
+  }: {
+    httpMethod: HttpMethod
+    path: string
+    middleware: RequestHandler
+  }) {
+    this.routes.push({
+      httpMethod,
+      path,
+      middleware,
+    })
+  }
 }
 
-export interface RouteConfig {
+export type RouteConfig = ControllerActionRouteConfig | MiddlewareRouteConfig
+
+interface BaseRouteConfig {
+  httpMethod: HttpMethod
+  path: string
+}
+
+export type ControllerActionRouteConfig = BaseRouteConfig & {
   controller: typeof PsychicController
   action: string
-  path: string
-  httpMethod: HttpMethod
+}
+
+export type MiddlewareRouteConfig = BaseRouteConfig & {
+  middleware: RequestHandler
 }

--- a/test-app/src/conf/app.ts
+++ b/test-app/src/conf/app.ts
@@ -198,6 +198,20 @@ export default async (psy: PsychicApp) => {
   // ******
   // HOOKS:
   // ******
+  psy.use((_, __, next) => {
+    __forTestingOnly('use')
+    next()
+  })
+
+  psy.use('before-middleware', (_, __, next) => {
+    __forTestingOnly('use:before-middleware')
+    next()
+  })
+
+  psy.use('after-middleware', (_, __, next) => {
+    __forTestingOnly('use:after-middleware')
+    next()
+  })
 
   // run a callback on server boot (but before routes are processed)
   psy.on('server:init:before-middleware', () => {

--- a/test-app/src/conf/app.ts
+++ b/test-app/src/conf/app.ts
@@ -228,7 +228,7 @@ export default async (psy: PsychicApp) => {
   })
 
   // run a callback after the config is loaded, but only if NODE_ENV=prod
-  psy.on('server:error', (err, req, res) => {
+  psy.on('server:error', (err, _, res) => {
     __forTestingOnly('server:error')
 
     if (debugEnabled) {

--- a/test-app/src/conf/routes.ts
+++ b/test-app/src/conf/routes.ts
@@ -152,4 +152,33 @@ export default (r: PsychicRouter) => {
   })
 
   r.get('/admin/test', AdminTestController, 'test')
+
+  // ensure that random middleware can still be provided top-level,
+  // same as with an express application
+  r.get('middleware-test', (_, res) => {
+    res.json('get middleware test')
+  })
+  r.post('middleware-test', (_, res) => {
+    res.json('post middleware test')
+  })
+  r.patch('middleware-test', (_, res) => {
+    res.json('patch middleware test')
+  })
+  r.put('middleware-test', (_, res) => {
+    res.json('put middleware test')
+  })
+  r.delete('middleware-test', (_, res) => {
+    res.json('delete middleware test')
+  })
+  r.options('middleware-test', (_, res) => {
+    res.json('options middleware test')
+  })
+
+  r.namespace('nested-middleware', r => {
+    // ensure that nested middleware can apply nested route
+    // paths correctly
+    r.get('middleware-test', (_, res) => {
+      res.json('nested middleware test')
+    })
+  })
 }


### PR DESCRIPTION
1.) `use` method is added to PsychicApp, enabling a user to easily apply express middleware during various stages of configuration.

```ts
psy.use((req, res, next) => {
  console.log('this will run BEFORE routes are processed')
  next()
})

psy.use('after-routes', (req, res, next) => {
  console.log('this will run AFTER routes are processed')
  next()
})
```

2.) within the routing layer, you can now provide middleware as a second argument to a route directly, rather than having to bypass psychic to do so.

```ts
r.get('middleware-test', (req, res, next) => {
  res.ok('hello world!')
})
```

This should enable us to integrate easily with services like passport, which require the ability to tap directly into express middleware. By leaning into express, we empower devs to take advantage of express easily, without creating any code clutter.

close https://rvohealth.atlassian.net/browse/PDTC-8034

