### PR TITLE
Leverage CliFileWriter to safely modify files during sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,7 @@ Fix route printing regression causing route printouts to show the path instead o
 ## 1.1.7
 
 - Add support for middleware arrays, enabling express plugins like passport
+
+## 1.1.8
+
+- Tap into CliFileWriter provided by dream to tap into file reversion for sync files, since the auto-sync function in psychic can fail and leave your file tree in a bad state.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "author": "RVOHealth",
   "repository": {
     "type": "git",
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@eslint/js": "^9.19.0",
     "@jest-mock/express": "^3.0.0",
-    "@rvoh/dream": "^1.0.2",
+    "@rvoh/dream": "^1.1.2",
     "@rvoh/dream-spec-helpers": "^1.0.0",
     "@rvoh/psychic-spec-helpers": "^1.0.0",
     "@types/express": "^5.0.1",

--- a/src/bin/helpers/generateRouteTypes.ts
+++ b/src/bin/helpers/generateRouteTypes.ts
@@ -1,5 +1,4 @@
-import { uniq } from '@rvoh/dream'
-import * as fs from 'node:fs/promises'
+import { CliFileWriter, uniq } from '@rvoh/dream'
 import * as path from 'node:path'
 import PsychicApp from '../../psychic-app/index.js'
 import { RouteConfig } from '../../router/route-manager.js'
@@ -12,5 +11,5 @@ export default async function generateRouteTypes(routes: RouteConfig[]) {
 
   const psychicApp = PsychicApp.getOrFail()
   const routeTypesPath = path.join(psychicApp.apiRoot, 'src', 'conf', 'routeTypes.ts')
-  await fs.writeFile(routeTypesPath, fileStr)
+  await CliFileWriter.write(routeTypesPath, fileStr)
 }

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -1,4 +1,4 @@
-import { DreamBin, DreamCLI } from '@rvoh/dream'
+import { CliFileWriter, DreamBin, DreamCLI } from '@rvoh/dream'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import TypesBuilder from '../cli/helpers/TypesBuilder.js'
@@ -67,26 +67,14 @@ export default class PsychicBin {
   }
 
   public static async postSync() {
-    const psychicApp = PsychicApp.getOrFail()
-    await PsychicBin.syncOpenapiJson()
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let output: any = {}
-
-    for (const hook of psychicApp.specialHooks.cliSync) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const res = await hook()
-      if (isObject(res)) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        output = { ...output, ...(res as object) }
-      }
+    try {
+      await this.syncOpenapiJson()
+      await this.runCliHooksAndUpdatePsychicTypesFileWithOutput()
+      await this.syncTypescriptOpenapiFiles()
+    } catch (error) {
+      console.error(error)
+      await CliFileWriter.revert()
     }
-
-    if (Object.keys(output as object).length) {
-      await PsychicBin.syncTypes(output)
-    }
-
-    await this.syncTypescriptOpenapiFiles()
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -132,8 +120,38 @@ export default class PsychicBin {
       // noop
     }
 
-    await fs.writeFile(outfile, enumsStr, {})
+    await CliFileWriter.write(outfile, enumsStr)
 
     DreamCLI.logger.logEndProgress()
+  }
+
+  /**
+   * @internal
+   *
+   * runs all the custom cli hooks provided for the user's application.
+   * if any of the cli hooks returns an object-based output, we will splat
+   * it all together into a single `output` variable, which we then
+   * feed into the `syncTypes` method to provide custom type data.
+   * This enables psychic plugins to add custom types to the psychic type
+   * bindings.
+   */
+  private static async runCliHooksAndUpdatePsychicTypesFileWithOutput() {
+    const psychicApp = PsychicApp.getOrFail()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let output: any = {}
+
+    for (const hook of psychicApp.specialHooks.cliSync) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const res = await hook()
+      if (isObject(res)) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        output = { ...output, ...(res as object) }
+      }
+    }
+
+    if (Object.keys(output as object).length) {
+      await PsychicBin.syncTypes(output)
+    }
   }
 }

--- a/src/cli/helpers/TypesBuilder.ts
+++ b/src/cli/helpers/TypesBuilder.ts
@@ -1,5 +1,4 @@
-import { DreamApp } from '@rvoh/dream'
-import * as fs from 'node:fs/promises'
+import { CliFileWriter, DreamApp } from '@rvoh/dream'
 import * as path from 'node:path'
 import PsychicApp from '../../psychic-app/index.js'
 
@@ -9,7 +8,7 @@ export default class TypesBuilder {
     const dreamApp = DreamApp.getOrFail()
     const schemaPath = path.join(dreamApp.projectRoot, dreamApp.paths.types, 'psychic.ts')
 
-    await fs.writeFile(schemaPath, this.build(customTypes))
+    await CliFileWriter.write(schemaPath, this.build(customTypes))
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/helpers/path.ts
+++ b/src/helpers/path.ts
@@ -1,9 +1,0 @@
-import { promises as fs } from 'node:fs'
-
-export async function loadFile(filepath: string) {
-  return await fs.readFile(filepath)
-}
-
-export async function writeFile(filepath: string, contents: string) {
-  return await fs.writeFile(filepath, contents)
-}

--- a/src/openapi-renderer/app.ts
+++ b/src/openapi-renderer/app.ts
@@ -1,5 +1,4 @@
-import { compact, groupBy, OpenapiSchemaBody, sortObjectByKey } from '@rvoh/dream'
-import * as fs from 'node:fs/promises'
+import { CliFileWriter, compact, groupBy, OpenapiSchemaBody, sortObjectByKey } from '@rvoh/dream'
 import { debuglog } from 'node:util'
 import UnexpectedUndefined from '../error/UnexpectedUndefined.js'
 import openapiJsonPath from '../helpers/openapiJsonPath.js'
@@ -31,9 +30,7 @@ export default class OpenapiAppRenderer {
     const psychicApp = PsychicApp.getOrFail()
     const asyncWriteOpenapiFile = async (key: string) => {
       const jsonPath = openapiJsonPath(key)
-      await fs.writeFile(jsonPath, JSON.stringify(openapiContents[key], null, 2), {
-        flag: 'w+',
-      })
+      await CliFileWriter.write(jsonPath, JSON.stringify(openapiContents[key], null, 2), { flag: 'w+' })
     }
 
     await Promise.all(Object.keys(psychicApp.openapi).map(key => asyncWriteOpenapiFile(key)))

--- a/yarn.lock
+++ b/yarn.lock
@@ -900,9 +900,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rvoh/dream@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@rvoh/dream@npm:1.0.2"
+"@rvoh/dream@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@rvoh/dream@npm:1.1.2"
   dependencies:
     colorette: "npm:^2.0.20"
     commander: "npm:^12.1.0"
@@ -917,7 +917,7 @@ __metadata:
     kysely: ^0.27.4
     kysely-codegen: ~0.17.0
     pg: "*"
-  checksum: 10c0/8bcf8ccf95363c39572916015e3412c772c883f028a3ff397418b0a9d4df6df543b9916d33feac9a520a74d8453cfce379cb04a22b8173784b53a358473a18a9
+  checksum: 10c0/0f96ca0f3297d9c620328d1849e84f791b91acdeb3f0fb418d67196193fe3d3d7ebdd65fdc60f53082780d2d9d2d8e3250b8264515894f2b0cd07892c78bdbea
   languageName: node
   linkType: hard
 
@@ -942,7 +942,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.19.0"
     "@jest-mock/express": "npm:^3.0.0"
-    "@rvoh/dream": "npm:^1.0.2"
+    "@rvoh/dream": "npm:^1.1.2"
     "@rvoh/dream-spec-helpers": "npm:^1.0.0"
     "@rvoh/psychic-spec-helpers": "npm:^1.0.0"
     "@types/cookie-parser": "npm:^1.4.8"


### PR DESCRIPTION
any files written using the CliFileWriter will be safely reverted if the sync throws an exception. The only caveat to this is that, if the error is thrown during post-sync (which is done as a separate CLI run after the initial dream sync), then all dream files will not be reverted back. The fact that sync and post-sync are run in separate threads means that in the future, if we want to build a system that does true file reversion across both commands, it would need to carefully do backups of all files before running the initial sync command, and those backups would need to be persisted to a file system somewhere so that they can be extracted during post-sync if a revert is needed at that stage. However, this should satisfy the 80-20 rule, and if we need to, we can go back to dream and modify the CliFileWriter to use the file system for caching backups, which will solve this issue without the need for another psychic PR.