### PR TITLE
Sort outputted enum values

### DIFF
--- a/src/bin/helpers/enumsFileStr.ts
+++ b/src/bin/helpers/enumsFileStr.ts
@@ -13,7 +13,10 @@ export default async function enumsFileStr() {
 
     enumsFileStr += `\
 export const ${exportedTypeName} = [
-  ${values.map(val => `'${val}'`).join(',\n  ')}
+  ${values
+    .sort()
+    .map(val => `'${val}'`)
+    .join(',\n  ')}
 ] as const
 
 `


### PR DESCRIPTION
I've noticed that [in PRs on clinical](https://github.com/rvohealth/wellos-clinical/pull/108/files#diff-7082936b0d9ed07366ba7386465ab320135896a08472d5d6479a09a6e1f06eaf) there is a lot of noise from the enums being rearranged, but no actual changes. I think that adding sort here will reduce that noise as well as improve the readability of the output.