### PR TITLE
add custom openapi validation, leveraging ajv

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "1.5.6",
+  "version": "1.6.0",
   "author": "RVOHealth",
   "repository": {
     "type": "git",
@@ -43,6 +43,8 @@
   "dependencies": {
     "@types/cookie-parser": "^1.4.8",
     "@types/cors": "^2.8.17",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "commander": "^12.1.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/spec/unit/helpers/validateOpenapiSchema.spec.ts
+++ b/spec/unit/helpers/validateOpenapiSchema.spec.ts
@@ -1,0 +1,147 @@
+import validateOpenApiSchema from '../../../src/helpers/validateOpenApiSchema.js'
+
+describe('validateOpenApiSchema', () => {
+  it('validates OpenAPI schemas with appropriate defaults', () => {
+    const openapiSchema = {
+      type: 'object',
+      properties: {
+        id: { type: 'string', format: 'uuid' },
+        name: { type: 'string' },
+        age: { type: 'integer', minimum: 0 },
+        email: { type: 'string', format: 'email' },
+      },
+      required: ['id', 'name'],
+    }
+
+    const validData = {
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      name: 'John Doe',
+      age: '30', // use string to verify implicit coercion
+      email: 'john@example.com',
+    }
+
+    const result = validateOpenApiSchema<typeof validData>(validData, openapiSchema)
+    expect(result.isValid).toBe(true)
+    expect(result.data!.age).toBe(30)
+
+    // ensure that original data is not mutated
+    expect(validData.age).toBe('30')
+  })
+
+  it('removes failing additional properties in OpenAPI mode without mutating original', () => {
+    const openapiSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+      additionalProperties: false,
+    }
+
+    const dataWithExtra = {
+      name: 'John',
+      invalidExtra: 'should be removed',
+    }
+
+    const result = validateOpenApiSchema<typeof dataWithExtra>(dataWithExtra, openapiSchema)
+    expect(result.isValid).toBe(true)
+    expect(result.data!.invalidExtra).toBeUndefined()
+    // Original data should not be mutated
+    expect(dataWithExtra.invalidExtra).toBe('should be removed')
+  })
+
+  it('handles OpenAPI-specific formats', () => {
+    const openapiSchema = {
+      type: 'object',
+      properties: {
+        date: { type: 'string', format: 'date' },
+        datetime: { type: 'string', format: 'date-time' },
+        uri: { type: 'string', format: 'uri' },
+        oneOfTest: {
+          oneOf: [
+            { type: 'string', format: 'uri' },
+            { type: 'number', format: 'date-time' },
+          ],
+        },
+        anyOfTest: {
+          anyOf: [
+            { type: 'string', format: 'uri' },
+            { type: 'string', format: 'date-time' },
+          ],
+        },
+      },
+    }
+
+    const validData = {
+      date: '2023-01-01',
+      datetime: '2023-01-01T10:00:00Z',
+      uri: 'https://example.com',
+      oneOfTest: 'https://example.com',
+      anyOfTest: '2023-01-01T10:00:00Z',
+    }
+
+    const result = validateOpenApiSchema(validData, openapiSchema)
+    expect(result.isValid).toBe(true)
+  })
+
+  it('returns detailed error information for OpenAPI validation failures', () => {
+    const openapiSchema = {
+      type: 'object',
+      properties: {
+        email: { type: 'string', format: 'email' },
+        age: { type: 'integer', minimum: 18 },
+      },
+      required: ['email', 'age'],
+    }
+
+    const invalidData = {
+      email: 'invalid-email',
+      age: 15,
+    }
+
+    const result = validateOpenApiSchema(invalidData, openapiSchema, { allErrors: true })
+    expect(result.isValid).toBe(false)
+    expect(result.errors).toBeDefined()
+    expect(result.errors!.length).toBeGreaterThan(0)
+
+    const emailError = result.errors!.find(err => err.instancePath === '/email')
+    const ageError = result.errors!.find(err => err.instancePath === '/age')
+
+    expect(emailError).toBeDefined()
+    expect(ageError).toBeDefined()
+  })
+
+  context('when provided a custom formats via a callback', () => {
+    it('applies the custom formats', () => {
+      const openapiSchema = {
+        type: 'object',
+        required: ['myField'],
+        properties: {
+          myField: {
+            type: 'string',
+            format: 'howyadoin',
+          },
+        },
+      }
+
+      const validResult = validateOpenApiSchema({ myField: 'howyadoin' }, openapiSchema, {
+        init: ajv => {
+          ajv.addFormat('howyadoin', {
+            type: 'string',
+            validate: data => data === 'howyadoin',
+          })
+        },
+      })
+      expect(validResult.isValid).toBe(true)
+
+      const invalidResult = validateOpenApiSchema({ myField: 'not-howyadoin' }, openapiSchema, {
+        init: ajv => {
+          ajv.addFormat('howyadoin', {
+            type: 'string',
+            validate: data => data === 'howyadoin',
+          })
+        },
+      })
+      expect(invalidResult.isValid).toBe(false)
+    })
+  })
+})

--- a/spec/unit/openapi-renderer/app/buildOpenapiObject.spec.ts
+++ b/spec/unit/openapi-renderer/app/buildOpenapiObject.spec.ts
@@ -3,8 +3,8 @@ import OpenapiAppRenderer from '../../../../src/openapi-renderer/app.js'
 describe('OpenapiAppRenderer', () => {
   describe('.toObject', () => {
     context('default', () => {
-      it('reads all default controllers and consolidates endpoints, also providing boilerplate openapi headers', async () => {
-        const response = await OpenapiAppRenderer.toObject()
+      it('reads all default controllers and consolidates endpoints, also providing boilerplate openapi headers', () => {
+        const response = OpenapiAppRenderer.toObject()
         expect(response.default).toEqual(
           expect.objectContaining({
             openapi: '3.1.0',
@@ -35,7 +35,7 @@ describe('OpenapiAppRenderer', () => {
                 description: 'custom header',
                 in: 'header',
                 name: 'custom-header',
-                required: true,
+                required: false,
                 schema: {
                   type: 'string',
                 },
@@ -69,7 +69,7 @@ describe('OpenapiAppRenderer', () => {
                 description: 'custom header',
                 in: 'header',
                 name: 'custom-header',
-                required: true,
+                required: false,
                 schema: {
                   type: 'string',
                 },
@@ -103,7 +103,7 @@ describe('OpenapiAppRenderer', () => {
                 description: 'custom header',
                 in: 'header',
                 name: 'custom-header',
-                required: true,
+                required: false,
                 schema: {
                   type: 'string',
                 },
@@ -484,18 +484,23 @@ describe('OpenapiAppRenderer', () => {
         expect(response.default!.components.schemas).toEqual(
           expect.objectContaining({
             ValidationErrors: {
-              type: 'object',
               properties: {
                 errors: {
-                  type: 'object',
                   additionalProperties: {
-                    type: 'array',
                     items: {
                       type: 'string',
                     },
+                    type: 'array',
                   },
+                  type: 'object',
+                },
+                type: {
+                  enum: ['validation'],
+                  type: 'string',
                 },
               },
+              required: ['type', 'errors'],
+              type: 'object',
             },
           }),
         )
@@ -524,13 +529,21 @@ describe('OpenapiAppRenderer', () => {
               },
 
               // 400
+
               BadRequest: {
                 description:
-                  'The server would not process the request due to something the server considered to be a client error',
+                  'The server would not process the request due to something the server considered to be a client error, such as a model validation failure or an openapi validation failure',
                 content: {
                   'application/json': {
                     schema: {
-                      $ref: '#/components/schemas/ValidationErrors',
+                      oneOf: [
+                        {
+                          $ref: '#/components/schemas/ValidationErrors',
+                        },
+                        {
+                          $ref: '#/components/schemas/OpenapiValidationErrors',
+                        },
+                      ],
                     },
                   },
                 },
@@ -583,8 +596,8 @@ describe('OpenapiAppRenderer', () => {
     })
 
     context('multiple openapi schemas', () => {
-      it('correctly renders all schemas in all secondary openapi files', async () => {
-        const response = await OpenapiAppRenderer.toObject()
+      it('correctly renders all schemas in all secondary openapi files', () => {
+        const response = OpenapiAppRenderer.toObject()
         const comment1Content = {
           type: 'object',
           required: ['howyadoin'],
@@ -597,8 +610,8 @@ describe('OpenapiAppRenderer', () => {
     })
 
     context('admin', () => {
-      it('reads all admin controllers and consolidates endpoints, also providing boilerplate admin openapi headers', async () => {
-        const response = await OpenapiAppRenderer.toObject()
+      it('reads all admin controllers and consolidates endpoints, also providing boilerplate admin openapi headers', () => {
+        const response = OpenapiAppRenderer.toObject()
 
         expect(response.admin).toEqual(
           expect.objectContaining({

--- a/spec/unit/openapi-renderer/endpoint/toPathObject.spec.ts
+++ b/spec/unit/openapi-renderer/endpoint/toPathObject.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { PsychicServer } from '../../../../src/index.js'
+import { PsychicApp } from '../../../../src/index.js'
 import OpenapiEndpointRenderer, { ToPathObjectOpts } from '../../../../src/openapi-renderer/endpoint.js'
 import { RouteConfig } from '../../../../src/router/route-manager.js'
 import ApiPetsController from '../../../../test-app/src/app/controllers/Api/PetsController.js'
@@ -17,7 +17,6 @@ import PostSerializer from '../../../../test-app/src/app/serializers/PostSeriali
 import UserSerializer, {
   UserWithPostsSerializer,
 } from '../../../../test-app/src/app/serializers/UserSerializer.js'
-import initializePsychicApp from '../../../../test-app/src/cli/helpers/initializePsychicApp.js'
 
 describe('OpenapiEndpointRenderer', () => {
   let routes: RouteConfig[]
@@ -33,11 +32,8 @@ describe('OpenapiEndpointRenderer', () => {
     }
   }
 
-  beforeAll(async () => {
-    await initializePsychicApp()
-    const server = new PsychicServer()
-    await server.boot()
-    routes = await server.routes()
+  beforeEach(() => {
+    routes = PsychicApp.getOrFail().routesCache
   })
 
   describe('#toPathObject', () => {
@@ -554,7 +550,7 @@ describe('OpenapiEndpointRenderer', () => {
                   {
                     in: 'header',
                     name: 'custom-header',
-                    required: true,
+                    required: false,
                     description: 'custom header',
                     schema: {
                       type: 'string',

--- a/spec/unit/openapi-renderer/endpoint/toSchemaObject.spec.ts
+++ b/spec/unit/openapi-renderer/endpoint/toSchemaObject.spec.ts
@@ -1,4 +1,4 @@
-import { PsychicServer } from '../../../../src/index.js'
+import { PsychicApp } from '../../../../src/index.js'
 import OpenapiEndpointRenderer, {
   ToPathObjectOpts,
   ToSchemaObjectOpts,
@@ -517,7 +517,7 @@ The following values will be allowed:
     })
 
     context('with a $serializer expression passed', () => {
-      it('supports an attribute with the $serializer expression', async () => {
+      it('supports an attribute with the $serializer expression', () => {
         const renderer = new OpenapiEndpointRenderer(
           CommentTestingRootSerializerRefSerializer,
           UsersController,
@@ -525,10 +525,7 @@ The following values will be allowed:
           {},
         )
 
-        const server = new PsychicServer()
-        await server.boot()
-        const routes = await server.routes()
-
+        const routes = PsychicApp.getOrFail().routesCache
         const pathObjectResponse = renderer.toPathObject(routes, defaultToPathObjectOpts())
         const toSchemaObjectOpts = defaultToSchemaObjectOpts({
           ...pathObjectResponse,
@@ -847,17 +844,14 @@ The following values will be allowed:
           })
         })
 
-        it('supports $serializer expression', async () => {
+        it('supports $serializer expression', () => {
           const renderer = new OpenapiEndpointRenderer(
             CommentTestingObjectWithSerializerRefSerializer,
             UsersController,
             'howyadoin',
           )
 
-          const server = new PsychicServer()
-          await server.boot()
-          const routes = await server.routes()
-
+          const routes = PsychicApp.getOrFail().routesCache
           const pathObjectResponse = renderer.toPathObject(routes, defaultToPathObjectOpts())
           const toSchemaObjectOpts = defaultToSchemaObjectOpts({
             ...pathObjectResponse,
@@ -1150,7 +1144,7 @@ The following values will be allowed:
     })
 
     context('when responses includes $serializer refs', () => {
-      it('extracts serializers and renders them in components.schemas', async () => {
+      it('extracts serializers and renders them in components.schemas', () => {
         const renderer = new OpenapiEndpointRenderer(
           CommentTestingBasicSerializerRefSerializer,
           UsersController,
@@ -1172,9 +1166,7 @@ The following values will be allowed:
           },
         )
 
-        const server = new PsychicServer()
-        await server.boot()
-        const routes = await server.routes()
+        const routes = PsychicApp.getOrFail().routesCache
 
         const pathObjectResponse = renderer.toPathObject(routes, defaultToPathObjectOpts())
         const toSchemaObjectOpts = defaultToSchemaObjectOpts({

--- a/spec/unit/openapi-renderer/helpers/OpenapiPayloadValidator.spec.ts
+++ b/spec/unit/openapi-renderer/helpers/OpenapiPayloadValidator.spec.ts
@@ -1,0 +1,80 @@
+import OpenapiEndpointRenderer from '../../../../src/openapi-renderer/endpoint.js'
+import OpenapiPayloadValidator from '../../../../src/openapi-renderer/helpers/OpenapiPayloadValidator.js'
+import UsersController from '../../../../test-app/src/app/controllers/UsersController.js'
+import User from '../../../../test-app/src/app/models/User.js'
+
+describe('OpenapiPayloadValidator', () => {
+  describe('#validateOpenapiHeaders', () => {
+    it('validates headers', () => {
+      const renderer = new OpenapiEndpointRenderer(User, UsersController, 'show', {
+        security: [{ customToken: [] }],
+        validate: { all: true },
+        headers: {
+          chalupas: {
+            required: true,
+            schema: {
+              type: 'string',
+              enum: ['delicious'],
+            },
+          },
+        },
+      })
+      const validator = new OpenapiPayloadValidator('default', renderer)
+      expect(() => validator.validateOpenapiHeaders({ chalupas: 'delicious' })).not.toThrow()
+      expect(() => validator.validateOpenapiHeaders({ chalupas: 'not delicious' })).toThrow()
+    })
+  })
+
+  describe('#validateOpenapiRequestBody', () => {
+    it('validates request bodies', () => {
+      const renderer = new OpenapiEndpointRenderer(User, UsersController, 'update', {
+        security: [{ customToken: [] }],
+        validate: { all: true },
+        requestBody: {
+          type: 'object',
+          properties: {
+            numericParam: 'number',
+          },
+        },
+      })
+      const validator = new OpenapiPayloadValidator('default', renderer)
+      expect(() => validator.validateOpenapiRequestBody({ numericParam: 123 })).not.toThrow()
+      expect(() => validator.validateOpenapiRequestBody({ numericParam: 'hello' })).toThrow()
+    })
+  })
+
+  describe('#validateOpenapiQuery', () => {
+    it('validates query params', () => {
+      const renderer = new OpenapiEndpointRenderer(User, UsersController, 'show', {
+        security: [{ customToken: [] }],
+        validate: { all: true },
+        query: {
+          numericParam: {
+            required: false,
+            schema: 'number',
+          },
+        },
+      })
+      const validator = new OpenapiPayloadValidator('default', renderer)
+      expect(() => validator.validateOpenapiQuery({ numericParam: 123 })).not.toThrow()
+      expect(() => validator.validateOpenapiQuery({ numericParam: 'hello' })).toThrow()
+    })
+  })
+
+  describe('#validateOpenapiResponseBody', () => {
+    it('validates response bodies', () => {
+      const renderer = new OpenapiEndpointRenderer(User, UsersController, 'show', {
+        security: [{ customToken: [] }],
+        validate: { all: true },
+        responses: {
+          200: {
+            type: 'number',
+          },
+        },
+      })
+      const validator = new OpenapiPayloadValidator('default', renderer)
+      expect(() => validator.validateOpenapiResponseBody(123, 200)).not.toThrow()
+      expect(() => validator.validateOpenapiResponseBody('hello', 200)).toThrow()
+    })
+  })
+})

--- a/spec/unit/psychic-application/openapiValidationIsActive.spec.ts
+++ b/spec/unit/psychic-application/openapiValidationIsActive.spec.ts
@@ -1,0 +1,164 @@
+import { PsychicApp } from '../../../src/index.js'
+import { OpenapiValidateOption } from '../../../src/openapi-renderer/endpoint.js'
+
+function mockValidationValue(val: OpenapiValidateOption) {
+  vi.spyOn(PsychicApp.prototype, 'openapi', 'get').mockReturnValue({
+    default: { validate: val, outputFilepath: '' },
+  })
+}
+
+describe('PsychicApp#openapiValidationIsActive', () => {
+  context('undefined', () => {
+    beforeEach(() => {
+      mockValidationValue(undefined as unknown as OpenapiValidateOption)
+    })
+
+    it('returns false for headers', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'headers')).toBe(false)
+    })
+
+    it('returns false for requestBody', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'requestBody')).toBe(false)
+    })
+
+    it('returns false for responseBody', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'responseBody')).toBe(false)
+    })
+
+    it('returns false for query', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'query')).toBe(false)
+    })
+  })
+
+  context('all: true', () => {
+    beforeEach(() => {
+      mockValidationValue({ all: true })
+    })
+
+    it('returns true for headers', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'headers')).toBe(true)
+    })
+
+    it('returns true for requestBody', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'requestBody')).toBe(true)
+    })
+
+    it('returns true for responseBody', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'responseBody')).toBe(true)
+    })
+
+    it('returns true for query', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'query')).toBe(true)
+    })
+  })
+
+  context('all: false', () => {
+    beforeEach(() => {
+      mockValidationValue({ all: false })
+    })
+
+    it('returns false for headers', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'headers')).toBe(false)
+    })
+
+    it('returns false for requestBody', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'requestBody')).toBe(false)
+    })
+
+    it('returns false for responseBody', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'responseBody')).toBe(false)
+    })
+
+    it('returns false for query', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'query')).toBe(false)
+    })
+  })
+
+  context('query: true', () => {
+    beforeEach(() => {
+      mockValidationValue({ query: true })
+    })
+
+    it('returns false for headers', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'headers')).toBe(false)
+    })
+
+    it('returns false for requestBody', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'requestBody')).toBe(false)
+    })
+
+    it('returns false for responseBody', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'responseBody')).toBe(false)
+    })
+
+    it('returns true for query', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'query')).toBe(true)
+    })
+  })
+
+  context('requestBody: true', () => {
+    beforeEach(() => {
+      mockValidationValue({ requestBody: true })
+    })
+
+    it('returns false for headers', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'headers')).toBe(false)
+    })
+
+    it('returns true for requestBody', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'requestBody')).toBe(true)
+    })
+
+    it('returns false for responseBody', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'responseBody')).toBe(false)
+    })
+
+    it('returns false for query', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'query')).toBe(false)
+    })
+  })
+
+  context('responseBody: true', () => {
+    beforeEach(() => {
+      mockValidationValue({ responseBody: true })
+    })
+
+    it('returns false for headers', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'headers')).toBe(false)
+    })
+
+    it('returns false for requestBody', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'requestBody')).toBe(false)
+    })
+
+    it('returns true for responseBody', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'responseBody')).toBe(true)
+    })
+
+    it('returns false for query', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'query')).toBe(false)
+    })
+  })
+
+  context('headers: true', () => {
+    beforeEach(() => {
+      mockValidationValue({ headers: true })
+    })
+
+    it('returns true for headers', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'headers')).toBe(true)
+    })
+
+    it('returns false for requestBody', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'requestBody')).toBe(false)
+    })
+
+    it('returns false for responseBody', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'responseBody')).toBe(false)
+    })
+
+    it('returns false for query', () => {
+      expect(PsychicApp.getOrFail().openapiValidationIsActive('default', 'query')).toBe(false)
+    })
+  })
+})

--- a/spec/unit/scenarios/openapi/validation/headers.spec.ts
+++ b/spec/unit/scenarios/openapi/validation/headers.spec.ts
@@ -1,0 +1,187 @@
+import { specRequest as request } from '@rvoh/psychic-spec-helpers'
+import { PsychicApp, PsychicServer } from '../../../../../src/index.js'
+import OpenapiEndpointRenderer from '../../../../../src/openapi-renderer/endpoint.js'
+
+describe('openapi validation', () => {
+  beforeEach(async () => {
+    await request.init(PsychicServer)
+  })
+
+  context('headers', () => {
+    context('with validation active on this openapi endpoint', () => {
+      beforeEach(() => {
+        // stubbing psychicApp to ensure that it does not produce a false positive
+        vi.spyOn(PsychicApp.prototype, 'openapiValidationIsActive').mockReturnValue(false)
+
+        vi.spyOn(OpenapiEndpointRenderer.prototype, 'shouldValidateHeaders').mockReturnValue(true)
+      })
+
+      context('with valid headers', () => {
+        it('permits the request', async () => {
+          const res = await request.get('/headersOpenapiTest', 200, {
+            headers: {
+              myDate: '2020-01-01',
+              myOptionalDate: '2020-01-01',
+              myOptionalInt: '123.0',
+            },
+          })
+          expect(res.body).toEqual({
+            myDate: '2020-01-01',
+            myOptionalDate: '2020-01-01',
+            myOptionalInt: '123.0',
+          })
+        })
+      })
+
+      context('with invalid headers', () => {
+        it('denies the request', async () => {
+          const res = await request.get('/headersOpenapiTest', 400, {
+            headers: {
+              myDate: '2020-01-ABC',
+              myOptionalDate: '2020-01-ABC',
+              myOptionalInt: '123.01',
+            },
+          })
+          expect(res.body).toEqual({
+            type: 'openapi',
+            target: 'headers',
+            errors: [
+              {
+                instancePath: '/myDate',
+                schemaPath: '#/properties/myDate/format',
+                keyword: 'format',
+                message: 'must match format "date"',
+                params: { format: 'date' },
+              },
+              {
+                instancePath: '/myOptionalDate',
+                schemaPath: '#/properties/myOptionalDate/format',
+                keyword: 'format',
+                message: 'must match format "date"',
+                params: { format: 'date' },
+              },
+              {
+                instancePath: '/myOptionalInt',
+                schemaPath: '#/properties/myOptionalInt/type',
+                keyword: 'type',
+                message: 'must be integer',
+                params: { type: 'integer' },
+              },
+            ],
+          })
+        })
+      })
+
+      context('with missing required headers', () => {
+        it('denies the request', async () => {
+          const res = await request.get('/headersOpenapiTest', 400)
+          expect(res.body).toEqual({
+            type: 'openapi',
+            target: 'headers',
+            errors: [
+              {
+                instancePath: '',
+                schemaPath: '#/required',
+                keyword: 'required',
+                message: "must have required property 'myDate'",
+                params: { missingProperty: 'myDate' },
+              },
+            ],
+          })
+        })
+      })
+
+      context('with missing non-required headers', () => {
+        it('permits the request', async () => {
+          await request.get('/headersOpenapiTest', 200, {
+            headers: {
+              myDate: '2020-01-01',
+            },
+          })
+        })
+      })
+    })
+
+    context('without validation active on this openapi endpoint', () => {
+      context('with validation active on the PsychicApp', () => {
+        beforeEach(() => {
+          vi.spyOn(PsychicApp.prototype, 'openapiValidationIsActive').mockReturnValue(true)
+        })
+
+        context('with valid headers', () => {
+          it('permits the request', async () => {
+            await request.get('/headersOpenapiTest', 200, {
+              headers: {
+                myDate: '2020-01-01',
+              },
+            })
+          })
+        })
+
+        context('with invalid headers', () => {
+          it('denies the request', async () => {
+            await request.get('/headersOpenapiTest', 400, {
+              headers: {
+                myDate: '2020-01-ABC',
+              },
+            })
+          })
+        })
+
+        context('with missing required headers', () => {
+          it('denies the request', async () => {
+            await request.get('/headersOpenapiTest', 400)
+          })
+        })
+
+        context('with missing non-required headers', () => {
+          it('permits the request', async () => {
+            await request.get('/headersOpenapiTest', 200, {
+              headers: {
+                myDate: '2020-01-01',
+              },
+            })
+          })
+        })
+      })
+
+      context('without validation active on the PsychicApp', () => {
+        beforeEach(() => {
+          vi.spyOn(PsychicApp.prototype, 'openapiValidationIsActive').mockReturnValue(false)
+        })
+
+        context('with valid headers', () => {
+          it('permits the request', async () => {
+            await request.get('/headersOpenapiTest', 200, {
+              headers: {
+                myDate: '2020-01-01',
+              },
+            })
+          })
+        })
+
+        context('with invalid headers', () => {
+          it('permits the request', async () => {
+            await request.get('/headersOpenapiTest', 200, {
+              headers: {
+                myDate: '2020-01-ABC',
+              },
+            })
+          })
+        })
+
+        context('with missing required headers', () => {
+          it('permits the request', async () => {
+            await request.get('/headersOpenapiTest', 200)
+          })
+        })
+
+        context('with missing non-required headers', () => {
+          it('permits the request', async () => {
+            await request.get('/headersOpenapiTest', 200)
+          })
+        })
+      })
+    })
+  })
+})

--- a/spec/unit/scenarios/openapi/validation/query.spec.ts
+++ b/spec/unit/scenarios/openapi/validation/query.spec.ts
@@ -1,0 +1,179 @@
+import { specRequest as request } from '@rvoh/psychic-spec-helpers'
+import { PsychicApp, PsychicServer } from '../../../../../src/index.js'
+import OpenapiEndpointRenderer from '../../../../../src/openapi-renderer/endpoint.js'
+
+describe('openapi validation', () => {
+  beforeEach(async () => {
+    await request.init(PsychicServer)
+  })
+
+  context('query', () => {
+    context('with validation active on this openapi endpoint', () => {
+      beforeEach(() => {
+        // stubbing psychicApp to ensure that it does not produce a false positive
+        vi.spyOn(PsychicApp.prototype, 'openapiValidationIsActive').mockReturnValue(false)
+
+        vi.spyOn(OpenapiEndpointRenderer.prototype, 'shouldValidateQuery').mockReturnValue(true)
+      })
+
+      context('with a valid query', () => {
+        it('permits the request', async () => {
+          await request.get('/queryOpenapiTest', 200, {
+            query: {
+              numericParam: 123,
+            },
+          })
+        })
+      })
+
+      context('with plausible coercion on the table', () => {
+        it('refrains from coercing query params', async () => {
+          const res = await request.get('/queryOpenapiTest', 200, {
+            query: {
+              numericParam: '123',
+            },
+          })
+          expect(res.body).toEqual({ numericParam: '123' })
+        })
+      })
+
+      context('with an invalid query', () => {
+        it('rejects the request', async () => {
+          const res = await request.get('/queryOpenapiTest', 400, {
+            query: {
+              numericParam: ['hello'],
+            },
+          })
+          expect(res.body).toEqual({
+            type: 'openapi',
+            target: 'query',
+            errors: [
+              {
+                instancePath: '/numericParam',
+                schemaPath: '#/properties/numericParam/type',
+                keyword: 'type',
+                message: 'must be number',
+                params: { type: 'number' },
+              },
+            ],
+          })
+        })
+      })
+
+      context('with missing required query params', () => {
+        it('denies the request', async () => {
+          const res = await request.get('/queryRequiredOpenapiTest', 400)
+          expect(res.body).toEqual({
+            type: 'openapi',
+            target: 'query',
+            errors: [
+              {
+                instancePath: '',
+                schemaPath: '#/required',
+                keyword: 'required',
+                message: "must have required property 'requiredStringParam'",
+                params: { missingProperty: 'requiredStringParam' },
+              },
+            ],
+          })
+        })
+      })
+
+      context('with missing non-required query params', () => {
+        it('permits the request', async () => {
+          await request.get('/queryRequiredOpenapiTest', 200, {
+            query: {
+              requiredStringParam: ['hello'],
+            },
+          })
+        })
+      })
+    })
+
+    context('without validation active on this openapi endpoint', () => {
+      context('with validation active on the PsychicApp', () => {
+        beforeEach(() => {
+          vi.spyOn(PsychicApp.prototype, 'openapiValidationIsActive').mockReturnValue(true)
+        })
+
+        context('with a valid query', () => {
+          it('permits the request', async () => {
+            await request.get('/queryOpenapiTest', 200, {
+              query: {
+                numericParam: 123,
+              },
+            })
+          })
+        })
+
+        context('with an invalid query', () => {
+          it('rejects the request', async () => {
+            await request.get('/queryOpenapiTest', 400, {
+              query: {
+                numericParam: 'hello',
+              },
+            })
+          })
+        })
+
+        context('with missing required query params', () => {
+          it('denies the request', async () => {
+            await request.get('/queryRequiredOpenapiTest', 400)
+          })
+        })
+
+        context('with missing non-required query params', () => {
+          it('permits the request', async () => {
+            await request.get('/queryRequiredOpenapiTest', 200, {
+              query: {
+                requiredStringParam: ['hello'],
+              },
+            })
+          })
+        })
+      })
+
+      context('without validation active on the PsychicApp', () => {
+        beforeEach(() => {
+          vi.spyOn(PsychicApp.prototype, 'openapiValidationIsActive').mockReturnValue(false)
+        })
+
+        context('with a valid query', () => {
+          it('permits the request', async () => {
+            await request.get('/queryOpenapiTest', 200, {
+              query: {
+                numericParam: 123,
+              },
+            })
+          })
+        })
+
+        context('with an invalid query', () => {
+          it('permits the request', async () => {
+            await request.get('/queryOpenapiTest', 200, {
+              query: {
+                numericParam: 'hello',
+              },
+            })
+          })
+        })
+
+        context('with missing required query params', () => {
+          it('permits the request', async () => {
+            await request.get('/queryRequiredOpenapiTest', 200)
+          })
+        })
+
+        context('with missing non-required query params', () => {
+          it('permits the request', async () => {
+            await request.get('/queryRequiredOpenapiTest', 200, {
+              query: {
+                requiredStringParam: ['hello'],
+              },
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/spec/unit/scenarios/openapi/validation/requestBody.spec.ts
+++ b/spec/unit/scenarios/openapi/validation/requestBody.spec.ts
@@ -1,0 +1,231 @@
+import { specRequest as request } from '@rvoh/psychic-spec-helpers'
+import { PsychicApp, PsychicServer } from '../../../../../src/index.js'
+import User from '../../../../../test-app/src/app/models/User.js'
+import OpenapiEndpointRenderer from '../../../../../src/openapi-renderer/endpoint.js'
+
+describe('openapi validation', () => {
+  beforeEach(async () => {
+    await request.init(PsychicServer)
+  })
+
+  context('requestBody', () => {
+    context('with validation active on this openapi endpoint', () => {
+      beforeEach(() => {
+        // stubbing psychicApp to ensure that it does not produce a false positive
+        vi.spyOn(PsychicApp.prototype, 'openapiValidationIsActive').mockReturnValue(false)
+
+        vi.spyOn(OpenapiEndpointRenderer.prototype, 'shouldValidateRequestBody').mockReturnValue(true)
+      })
+
+      context('with a valid requestBody', () => {
+        it('permits the request', async () => {
+          const user = await User.create({ email: 'how@yadoin', password: 'howyadoin' })
+          await request.post('/pets', 201, {
+            data: {
+              name: 'aster',
+              species: 'cat',
+              nonNullSpecies: 'cat',
+              nonNullFavoriteTreats: [],
+              userId: user.id,
+            },
+          })
+
+          const aster = await user.associationQuery('pets').firstOrFail()
+          expect(aster.name).toEqual('aster')
+        })
+      })
+
+      context('with an invalid requestBody', () => {
+        it('denies the request', async () => {
+          const user = await User.create({ email: 'how@yadoin', password: 'howyadoin' })
+          const res = await request.post('/pets', 400, {
+            data: {
+              name: ['abc'],
+              species: 'cat',
+              nonNullSpecies: 'cat',
+              nonNullFavoriteTreats: [],
+              userId: user.id,
+            },
+          })
+          expect(res.body).toEqual({
+            type: 'openapi',
+            target: 'requestBody',
+            errors: [
+              {
+                instancePath: '/name',
+                schemaPath: '#/properties/name/type',
+                keyword: 'type',
+                message: 'must be string,null',
+                params: { type: ['string', 'null'] },
+              },
+            ],
+          })
+        })
+      })
+
+      context('with missing required fields', () => {
+        it('denies the request', async () => {
+          const res = await request.post('/requestBodyOpenapiTest', 400)
+          expect(res.body).toEqual({
+            type: 'openapi',
+            target: 'requestBody',
+            errors: [
+              {
+                instancePath: '',
+                schemaPath: '#/required',
+                keyword: 'required',
+                message: "must have required property 'requiredInt'",
+                params: { missingProperty: 'requiredInt' },
+              },
+            ],
+          })
+        })
+      })
+
+      context('with missing non-required fields', () => {
+        it('permits the request', async () => {
+          await request.post('/requestBodyOpenapiTest', 204, {
+            data: {
+              requiredInt: 123,
+            },
+          })
+        })
+      })
+    })
+
+    context('without validation active on this openapi endpoint', () => {
+      context('with validation active on the PsychicApp', () => {
+        beforeEach(() => {
+          vi.spyOn(PsychicApp.prototype, 'openapiValidationIsActive').mockReturnValue(true)
+        })
+
+        context('with a valid requestBody', () => {
+          it('permits the request', async () => {
+            const user = await User.create({ email: 'how@yadoin', password: 'howyadoin' })
+            await request.post('/pets', 201, {
+              data: {
+                name: 'aster',
+                species: 'cat',
+                nonNullSpecies: 'cat',
+                nonNullFavoriteTreats: [],
+                userId: user.id,
+              },
+            })
+
+            const aster = await user.associationQuery('pets').firstOrFail()
+            expect(aster.name).toEqual('aster')
+          })
+        })
+
+        context('with an invalid requestBody', () => {
+          it('denies the request', async () => {
+            const user = await User.create({ email: 'how@yadoin', password: 'howyadoin' })
+            await request.post('/pets', 400, {
+              data: {
+                name: ['abc'],
+                species: 'cat',
+                nonNullSpecies: 'cat',
+                nonNullFavoriteTreats: [],
+                userId: user.id,
+              },
+            })
+          })
+        })
+
+        context('with invalid nested requestBody fields', () => {
+          it('denies the request', async () => {
+            await request.post('/requestBodyNestedObjectOpenapiTest', 400, {
+              data: {
+                nested: {
+                  object: {
+                    requiredInt: ['abc'],
+                  },
+                },
+              },
+            })
+          })
+        })
+
+        context('with missing required fields', () => {
+          it('denies the request', async () => {
+            await request.post('/requestBodyOpenapiTest', 400)
+          })
+        })
+
+        context('with missing nested required fields', () => {
+          it('denies the request', async () => {
+            await request.post('/requestBodyNestedObjectOpenapiTest', 400, {
+              data: {
+                nested: {
+                  object: {
+                    optionalInt: 123,
+                  },
+                },
+              },
+            })
+          })
+        })
+
+        context('with missing non-required fields', () => {
+          it('permits the request', async () => {
+            await request.post('/requestBodyOpenapiTest', 204, {
+              data: {
+                requiredInt: 123,
+              },
+            })
+          })
+        })
+      })
+
+      context('without validation active on the PsychicApp', () => {
+        beforeEach(() => {
+          vi.spyOn(PsychicApp.prototype, 'openapiValidationIsActive').mockReturnValue(false)
+        })
+
+        context('with a valid requestBody', () => {
+          it('permits the request', async () => {
+            const user = await User.create({ email: 'how@yadoin', password: 'howyadoin' })
+            await request.post('/pets', 201, {
+              data: {
+                name: 'aster',
+                species: 'cat',
+                nonNullSpecies: 'cat',
+                nonNullFavoriteTreats: [],
+                userId: user.id,
+              },
+            })
+
+            const aster = await user.associationQuery('pets').firstOrFail()
+            expect(aster.name).toEqual('aster')
+          })
+        })
+
+        context('with an invalid requestBody', () => {
+          it('permits the request', async () => {
+            await request.post('/invalidRequestBody', 200, {
+              data: {
+                numericParam: 'hello world',
+              },
+            })
+          })
+        })
+
+        context('with missing required fields', () => {
+          it('permits the request', async () => {
+            await request.post('/requestBodyOpenapiTest', 204)
+          })
+        })
+
+        context('with missing non-required fields', () => {
+          it('permits the request', async () => {
+            await request.post('/requestBodyOpenapiTest', 204, {
+              data: {
+                requiredInt: 123,
+              },
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/spec/unit/scenarios/openapi/validation/responseBody.spec.ts
+++ b/spec/unit/scenarios/openapi/validation/responseBody.spec.ts
@@ -1,0 +1,185 @@
+import { specRequest as request } from '@rvoh/psychic-spec-helpers'
+import { PsychicApp, PsychicServer } from '../../../../../src/index.js'
+import OpenapiEndpointRenderer from '../../../../../src/openapi-renderer/endpoint.js'
+
+describe('openapi validation', () => {
+  beforeEach(async () => {
+    await request.init(PsychicServer)
+  })
+
+  context('responseBody', () => {
+    context('with validation active on this openapi endpoint', () => {
+      beforeEach(() => {
+        // stubbing psychicApp to ensure that it does not produce a false positive
+        vi.spyOn(PsychicApp.prototype, 'openapiValidationIsActive').mockReturnValue(false)
+
+        vi.spyOn(OpenapiEndpointRenderer.prototype, 'shouldValidateResponseBody').mockReturnValue(true)
+      })
+
+      context('with a valid response body', () => {
+        it('permits the request', async () => {
+          const res = await request.get('/responseBodyOpenapiTest', 200, {
+            query: {
+              renderMe: '123',
+            },
+          })
+          expect(res.body).toEqual('123')
+        })
+      })
+
+      context('with an invalid response body', () => {
+        it('rejects the request', async () => {
+          await request.get('/responseBodyOpenapiTest', 500, {
+            query: {
+              renderMe: ['hello'],
+            },
+          })
+        })
+
+        context('with an invalid, null response body', () => {
+          it('rejects the request', async () => {
+            await request.get('/responseBodyOpenapiTest', 500, {
+              query: {
+                renderMe: null,
+              },
+            })
+          })
+        })
+
+        context('with an invalid, null response body', () => {
+          it('rejects the request', async () => {
+            await request.get('/responseBodyOpenapiTest', 500, {
+              query: {
+                renderMe: undefined,
+              },
+            })
+          })
+        })
+      })
+
+      context('with missing required fields', () => {
+        it('denies the request', async () => {
+          await request.get('/responseBodyObjectOpenapiTest', 500, {
+            query: {
+              optionalInt: 123,
+            },
+          })
+        })
+      })
+
+      context('with missing nested required fields', () => {
+        it('denies the request', async () => {
+          await request.get('/responseBodyNestedObjectOpenapiTest', 500, {
+            query: {
+              optionalInt: 123,
+            },
+          })
+        })
+      })
+
+      context('with missing non-required fields', () => {
+        it('permits the request', async () => {
+          await request.get('/responseBodyObjectOpenapiTest', 200, {
+            query: {
+              requiredInt: 123,
+            },
+          })
+        })
+      })
+    })
+
+    context('without validation active on this openapi endpoint', () => {
+      context('with validation active on the PsychicApp', () => {
+        beforeEach(() => {
+          vi.spyOn(PsychicApp.prototype, 'openapiValidationIsActive').mockReturnValue(true)
+        })
+
+        context('with a valid response body', () => {
+          it('permits the request', async () => {
+            await request.get('/responseBodyOpenapiTest', 200, {
+              query: {
+                renderMe: 123,
+              },
+            })
+          })
+        })
+
+        context('with an invalid response body', () => {
+          it('rejects the request', async () => {
+            await request.get('/responseBodyOpenapiTest', 500, {
+              query: {
+                renderMe: 'hello',
+              },
+            })
+          })
+        })
+
+        context('with missing required fields', () => {
+          it('denies the request', async () => {
+            await request.get('/responseBodyObjectOpenapiTest', 500, {
+              query: {
+                optionalInt: 123,
+              },
+            })
+          })
+        })
+
+        context('with missing non-required fields', () => {
+          it('permits the request', async () => {
+            await request.get('/responseBodyObjectOpenapiTest', 200, {
+              query: {
+                requiredInt: 123,
+              },
+            })
+          })
+        })
+      })
+
+      context('without validation active on the PsychicApp', () => {
+        beforeEach(() => {
+          vi.spyOn(PsychicApp.prototype, 'openapiValidationIsActive').mockReturnValue(false)
+        })
+
+        context('with a valid response body', () => {
+          it('permits the request', async () => {
+            await request.get('/responseBodyOpenapiTest', 200, {
+              query: {
+                renderMe: 123,
+              },
+            })
+          })
+        })
+
+        context('with an invalid response body', () => {
+          it('permits the request', async () => {
+            await request.get('/responseBodyOpenapiTest', 200, {
+              query: {
+                renderMe: 'hello',
+              },
+            })
+          })
+        })
+
+        context('with missing required fields', () => {
+          it('permits the request', async () => {
+            await request.get('/responseBodyObjectOpenapiTest', 200, {
+              query: {
+                optionalInt: 123,
+              },
+            })
+          })
+        })
+
+        context('with missing non-required fields', () => {
+          it('permits the request', async () => {
+            await request.get('/responseBodyObjectOpenapiTest', 200, {
+              query: {
+                requiredInt: 123,
+              },
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/spec/unit/scenarios/response-statuses/200-ok.spec.ts
+++ b/spec/unit/scenarios/response-statuses/200-ok.spec.ts
@@ -10,4 +10,18 @@ describe('a visitor attempts to hit a route that will respond with a 200', () =>
     const res = await request.get('/ok', 200)
     expect(res.body).toEqual('custom content')
   })
+
+  context('rendering undefined', () => {
+    it('returns 200, rendering a blank object', async () => {
+      const res = await request.get('/ok-undefined', 200)
+      expect(res.body).toEqual({})
+    })
+  })
+
+  context('rendering null', () => {
+    it('returns 200, rendering null', async () => {
+      const res = await request.get('/ok-null', 200)
+      expect(res.body).toBeNull()
+    })
+  })
 })

--- a/spec/unit/scenarios/saving-records.spec.ts
+++ b/spec/unit/scenarios/saving-records.spec.ts
@@ -22,7 +22,7 @@ describe('a visitor attempts to save a record', () => {
   context('with a record that is invalid at Dream validation level', () => {
     it('does not save, returns 422', async () => {
       const res = await request.post('/failed-to-save-test', 422)
-      expect(res.body).toEqual({ errors: { email: ['contains'] } })
+      expect(res.body).toEqual({ type: 'validator', errors: { email: ['contains'] } })
     })
   })
 
@@ -54,7 +54,10 @@ describe('a visitor attempts to save a record', () => {
         const response = await request.post('/users', 400, {
           data: { user: { email: 123, password: 'howyadoin', name: 456 } },
         })
-        expect(response.body).toEqual({ errors: { email: ['expected string'], name: ['expected string'] } })
+        expect(response.body).toEqual({
+          type: 'validator',
+          errors: { email: ['expected string'], name: ['expected string'] },
+        })
         expect(await User.count()).toEqual(0)
       })
     },

--- a/src/bin/helpers/printRoutes.ts
+++ b/src/bin/helpers/printRoutes.ts
@@ -1,13 +1,9 @@
 import colors from 'yoctocolors'
 import { ControllerActionRouteConfig, RouteConfig } from '../../router/route-manager.js'
-import PsychicServer from '../../server/index.js'
+import PsychicApp from '../../psychic-app/index.js'
 
-export default async function printRoutes() {
-  const server = new PsychicServer()
-  await server.boot()
-
-  const routes = await server.routes()
-  const expressions = buildExpressions(routes)
+export default function printRoutes() {
+  const expressions = buildExpressions(PsychicApp.getOrFail().routesCache)
 
   // NOTE: intentionally doing this outside of the expression loop below
   // to avoid N+1

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -7,7 +7,6 @@ import generateResource from '../generate/resource.js'
 import isObject from '../helpers/isObject.js'
 import OpenapiAppRenderer from '../openapi-renderer/app.js'
 import PsychicApp from '../psychic-app/index.js'
-import PsychicServer from '../server/index.js'
 import enumsFileStr from './helpers/enumsFileStr.js'
 import generateRouteTypes from './helpers/generateRouteTypes.js'
 import printRoutes from './helpers/printRoutes.js'
@@ -36,8 +35,8 @@ export default class PsychicBin {
     await generateResource({ route, fullyQualifiedModelName, columnsWithTypes, options })
   }
 
-  public static async routes() {
-    await printRoutes()
+  public static printRoutes() {
+    printRoutes()
   }
 
   public static async sync({
@@ -108,11 +107,7 @@ export default class PsychicBin {
   public static async syncRoutes() {
     DreamCLI.logger.logStartProgress(`syncing routes...`)
 
-    const server = new PsychicServer()
-    await server.boot()
-
-    const routes = await server.routes()
-    await generateRouteTypes(routes)
+    await generateRouteTypes(PsychicApp.getOrFail().routesCache)
 
     DreamCLI.logger.logEndProgress()
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -251,7 +251,7 @@ export default class PsychicCLI {
       )
       .action(async () => {
         await initializePsychicApp()
-        await PsychicBin.routes()
+        PsychicBin.printRoutes()
         process.exit()
       })
 

--- a/src/error/openapi/OpenapResponseValidationFailure.ts
+++ b/src/error/openapi/OpenapResponseValidationFailure.ts
@@ -1,0 +1,3 @@
+import OpenapiValidationFailure from './OpenapiValidationFailure.js'
+
+export default class OpenapiResponseValidationFailure extends OpenapiValidationFailure {}

--- a/src/error/openapi/OpenapiRequestValidationFailure.ts
+++ b/src/error/openapi/OpenapiRequestValidationFailure.ts
@@ -1,0 +1,3 @@
+import OpenapiValidationFailure from './OpenapiValidationFailure.js'
+
+export default class OpenapiRequestValidationFailure extends OpenapiValidationFailure {}

--- a/src/error/openapi/OpenapiValidationFailure.ts
+++ b/src/error/openapi/OpenapiValidationFailure.ts
@@ -1,0 +1,18 @@
+import { OpenapiValidateTarget } from '../../openapi-renderer/endpoint.js'
+
+export default class OpenapiValidationFailure extends Error {
+  constructor(
+    public errors: OpenapiValidationError[],
+    public target: OpenapiValidateTarget,
+  ) {
+    super()
+  }
+}
+
+export type OpenapiValidationError = {
+  instancePath: string
+  schemaPath: string
+  keyword: string
+  message: string
+  params?: Record<string, unknown>
+}

--- a/src/error/psychic-app/must-call-psychic-app-init-first.ts
+++ b/src/error/psychic-app/must-call-psychic-app-init-first.ts
@@ -1,0 +1,20 @@
+export default class MustCallPsychicAppInitFirst extends Error {
+  constructor() {
+    super()
+  }
+
+  public override get message() {
+    return `
+      For some reason, PsychicApp.init was never called. In order for the
+      execution context to proceed, you must first ensure that PsychicApp.init
+      has been called. Usually, this is done by calling
+
+        await initializePsychicApp()
+
+      which is set up in your application boilerplate for you by default for
+      the relevant execution contexts. Perhaps it was mistakenly removed, or
+      otherwise you are trying to implement a new entrypoint into psychic, at
+      which case, please make sure to call 'await initializePsychicApp()' first
+    `
+  }
+}

--- a/src/helpers/validateOpenApiSchema.ts
+++ b/src/helpers/validateOpenApiSchema.ts
@@ -1,0 +1,187 @@
+import { Ajv, type ErrorObject, type JSONSchemaType, type ValidateFunction } from 'ajv'
+import addFormats from 'ajv-formats'
+
+/**
+ * @internal
+ *
+ * Validates an object against an OpenAPI schema
+ * Convenience wrapper around validateObject with OpenAPI-friendly defaults.
+ *
+ * This function is used internally by the OpenapiPayloadValidator
+ * class to correctly validate request body, query, headers,
+ * and response body.
+ *
+ * @param data - Object to validate
+ * @param openapiSchema - OpenAPI schema object
+ * @param options - (Optional) options to provide when initializing the ajv instance
+ * @returns ValidationResult
+ *
+ * @example
+ *
+ * ```ts
+ * const schema = {
+ *   type: 'object',
+ *   properties: {
+ *     name: { type: 'string' },
+ *     age: { type: 'integer', minimum: 0 }
+ *   },
+ *   required: ['name']
+ * }
+ *
+ * const result = validateOpenApiSchema({ name: 'John', age: 30 }, schema)
+ * if (result.isValid) {
+ *   console.log('Valid data:', result.data)
+ * } else {
+ *   console.log('Validation errors:', result.errors)
+ * }
+ * ```
+ */
+export default function validateOpenApiSchema<T = unknown>(
+  data: unknown,
+  openapiSchema: object,
+  options: ValidateOpenapiSchemaOptions = {},
+): ValidationResult<T> {
+  return validateObject<T>(data, openapiSchema, {
+    removeAdditional: 'failing', // Remove properties that fail validation
+    useDefaults: true,
+    coerceTypes: true,
+    ...options,
+  })
+}
+
+/**
+ * @internal
+ *
+ * Validates an object against a JSON schema using AJV
+ *
+ * @param data - Object to validate
+ * @param schema - JSON Schema to validate against
+ * @param options - Validation options
+ * @returns ValidationResult with success status, validated data, and any errors
+ */
+export function validateObject<T = unknown>(
+  data: unknown,
+  schema: JSONSchemaType<T> | object,
+  options: ValidateOpenapiSchemaOptions = {},
+): ValidationResult<T> {
+  try {
+    const validate = createValidator<T>(schema, options)
+    // Clone the data to prevent AJV from mutating the original object
+    const clonedData = structuredClone(data)
+    const isValid = validate(clonedData)
+
+    if (isValid) {
+      return {
+        isValid: true,
+        data: clonedData,
+      }
+    } else {
+      return {
+        isValid: false,
+        errors: formatAjvErrors(validate.errors || []),
+      }
+    }
+  } catch (error) {
+    // Handle schema compilation errors
+    return {
+      isValid: false,
+      errors: [
+        {
+          instancePath: '',
+          schemaPath: '',
+          keyword: 'schema',
+          message: error instanceof Error ? error.message : 'Schema compilation failed',
+        },
+      ],
+    }
+  }
+}
+
+/**
+ * @internal
+ *
+ * Creates an AJV validator function for validating objects against JSON schemas
+ *
+ * @param schema - JSON Schema to validate against
+ * @param options - Validation options
+ * @returns A validator function that can be reused for multiple validations
+ */
+export function createValidator<T = unknown>(
+  schema: JSONSchemaType<T> | object,
+  options: ValidateOpenapiSchemaOptions = {},
+): ValidateFunction<T> {
+  const ajvOptions = {
+    ...options,
+    init: undefined,
+  }
+
+  const ajv = new Ajv({
+    removeAdditional: false,
+    useDefaults: true,
+    coerceTypes: true,
+    strict: false, // Allow unknown keywords for OpenAPI compatibility
+    allErrors: options.allErrors || false, // Collect all errors, not just the first one
+    validateFormats: true, // Enable format validation for date-time, email, etc.
+    ...ajvOptions,
+  })
+
+  // unfortunately, the Node16 resolution does not play
+  // nicely with the addFormats function, since it is
+  // stuck in commonjs. Typescript cannot resolve types
+  // correctly, but after building and being consumed
+  // on the other side of a build, this is the only
+  // way to actually call the addFormats function without
+  // it breaking.
+  ;(addFormats as unknown as (ajv: unknown) => void)(ajv)
+
+  ajv.addFormat('decimal', {
+    type: 'string',
+    validate: data => DECIMAL_REGEX.test(data),
+  })
+
+  ajv.addFormat('bigint', {
+    type: 'string',
+    validate: data => BIGINT_REGEX.test(data),
+  })
+
+  options?.init?.(ajv)
+
+  return ajv.compile(schema) as ValidateFunction<T>
+}
+
+const DECIMAL_REGEX = /^-?(\d+\.?\d*|\.\d+)$/
+const BIGINT_REGEX = /^-?\d+(\.0*)?$/
+
+/**
+ * Formats AJV errors into a more readable format
+ */
+function formatAjvErrors(ajvErrors: ErrorObject[]): ValidationError[] {
+  return ajvErrors.map(error => ({
+    instancePath: error.instancePath,
+    schemaPath: error.schemaPath,
+    keyword: error.keyword,
+    message: error.message || 'Validation failed',
+    params: error.params,
+  }))
+}
+
+export interface ValidationResult<T = unknown> {
+  isValid: boolean
+  data?: T
+  errors?: ValidationError[]
+}
+
+export interface ValidationError {
+  instancePath: string
+  schemaPath: string
+  keyword: string
+  message: string
+  params?: Record<string, unknown>
+}
+
+export type AjvValidationOpts = ConstructorParameters<typeof Ajv>[0]
+export type ValidateOpenapiSchemaOptions = AjvValidationOpts & CustomOpenapiValidationOptions
+
+export interface CustomOpenapiValidationOptions {
+  init?: (ajv: Ajv) => void
+}

--- a/src/openapi-renderer/helpers/OpenapiPayloadValidator.ts
+++ b/src/openapi-renderer/helpers/OpenapiPayloadValidator.ts
@@ -1,0 +1,306 @@
+import OpenapiRequestValidationFailure from '../../error/openapi/OpenapiRequestValidationFailure.js'
+import OpenapiResponseValidationFailure from '../../error/openapi/OpenapResponseValidationFailure.js'
+import validateOpenApiSchema, { ValidateOpenapiSchemaOptions } from '../../helpers/validateOpenApiSchema.js'
+import PsychicApp from '../../psychic-app/index.js'
+import OpenapiEndpointRenderer, {
+  OpenapiContent,
+  OpenapiParameterResponse,
+  OpenapiRenderOpts,
+  OpenapiValidateTarget,
+} from '../endpoint.js'
+import suppressResponseEnumsConfig from './suppressResponseEnumsConfig.js'
+
+/**
+ * @internal
+ *
+ * Used to validate specific parts of a request, such
+ * as the body or headers, as well as the response body.
+ */
+export default class OpenapiPayloadValidator {
+  constructor(
+    /**
+     * the openapiName to validate against
+     */
+    private openapiName: string,
+
+    /**
+     * the OpenapiEndpointRenderer attached to the controller
+     * for this particular action
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private openapiEndpointRenderer: OpenapiEndpointRenderer<any, any>,
+  ) {}
+
+  /**
+   * @internal
+   *
+   * validates the provided request body against the request body
+   * shape specified by the openapi decorator. Will bypass validation
+   * unless validation is explicitly activated for requestBody at
+   * either the OpenAPI decorator level, or else the openapi config
+   * for the provided openapiName.
+   *
+   * @param body - the request body
+   */
+  public validateOpenapiRequestBody(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    body: any,
+  ): void {
+    const openapiEndpointRenderer = this.openapiEndpointRenderer
+    const openapiName = this.openapiName
+    const routes = PsychicApp.getOrFail().routesCache
+
+    if (openapiEndpointRenderer.shouldValidateRequestBody(openapiName)) {
+      const openapiPathObject = openapiEndpointRenderer['computedRequestBody'](routes, {
+        openapiName: 'default',
+        renderOpts: this.renderOpts,
+      })
+
+      const requestBodySchema = openapiPathObject?.['content']?.['application/json']?.['schema']
+      if (requestBodySchema) {
+        this.validateOrFail(body, requestBodySchema, 'requestBody')
+      }
+    }
+  }
+
+  /**
+   * @internal
+   *
+   * validates the provided request headers against the header
+   * shape specified by the openapi decorator. Will bypass validation
+   * unless validation is explicitly activated for headers at
+   * either the OpenAPI decorator level, or else the openapi config
+   * for the provided openapiName.
+   *
+   * @param headers - the request headers
+   */
+  public validateOpenapiHeaders(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    headers: any,
+  ): void {
+    const openapiEndpointRenderer = this.openapiEndpointRenderer
+    const openapiName = this.openapiName
+
+    if (openapiEndpointRenderer.shouldValidateHeaders(openapiName)) {
+      const headerSchemas = openapiEndpointRenderer['headersArray']({
+        openapiName,
+      })
+
+      const camelizedHeaders = this.camelizedOpenapiHeaders(headers, headerSchemas)
+      this.validateOrFail(
+        camelizedHeaders,
+        this.openapiParameterResponsesToSchemaObject(headerSchemas),
+        'headers',
+      )
+    }
+  }
+
+  /**
+   * @internal
+   *
+   * validates the provided request headers against the header
+   * shape specified by the openapi decorator. Will bypass validation
+   * unless validation is explicitly activated for headers at
+   * either the OpenAPI decorator level, or else the openapi config
+   * for the provided openapiName.
+   *
+   * @param query - the request query params
+   */
+  public validateOpenapiQuery(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    query: any,
+  ): void {
+    const openapiEndpointRenderer = this.openapiEndpointRenderer
+    const openapiName = this.openapiName
+
+    if (openapiEndpointRenderer.shouldValidateQuery(openapiName)) {
+      const openapiQueryParams = openapiEndpointRenderer['queryArray']({
+        openapiName: 'default',
+        renderOpts: this.renderOpts,
+      })
+
+      this.validateOrFail(query, this.openapiParameterResponsesToSchemaObject(openapiQueryParams), 'query')
+    }
+  }
+
+  /**
+   * @internal
+   *
+   * validates the rendered response body against the response
+   * shape specified by the openapi decorator. Will bypass validation
+   * unless validation is explicitly activated for responseBody at
+   * either the OpenAPI decorator level, or else the openapi config
+   * for the provided openapiName.
+   *
+   * @param data - the response body
+   * @param statusCode - the status code used to render
+   */
+  public validateOpenapiResponseBody(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    data: any,
+    statusCode: number,
+  ): void {
+    const openapiEndpointRenderer = this.openapiEndpointRenderer
+    const openapiName = this.openapiName
+
+    if (openapiEndpointRenderer.shouldValidateResponseBody(openapiName)) {
+      const openapiResponseBody = openapiEndpointRenderer['parseResponses']({
+        openapiName: this.openapiName,
+        renderOpts: this.renderOpts,
+      }).openapi?.[statusCode.toString() as '200'] as OpenapiContent
+      const schema = openapiResponseBody?.['content']?.['application/json']?.['schema']
+
+      if (schema) {
+        this.validateOrFail(data, schema as object, 'responseBody')
+      }
+    }
+  }
+
+  /**
+   * @internal
+   *
+   * return renderOpts that would be used for this endpoint
+   */
+  private get renderOpts(): OpenapiRenderOpts {
+    return {
+      casing: 'camel',
+      suppressResponseEnums: suppressResponseEnumsConfig(this.openapiName),
+    }
+  }
+
+  /**
+   * @internal
+   *
+   * transforms the headerSchemas array provided into an object that can
+   * be used to validate against the headers provided in the request
+   *
+   * @param openapiParams - the array of headers computed by the openapi endpoint renderer
+   * @returns the same headers object, but any headers matching those in the openapi schema are camelized
+   */
+  private openapiParameterResponsesToSchemaObject(
+    /**
+     * either the headers or query parameters of a request
+     */
+    openapiParams: OpenapiParameterResponse[],
+  ) {
+    const properties = openapiParams.reduce(
+      (agg, headerSchema) => {
+        agg[headerSchema.name] = headerSchema.schema
+        return agg
+      },
+      {} as Record<string, unknown>,
+    )
+
+    return {
+      type: 'object',
+      required: openapiParams.filter(schema => schema.required).map(schema => schema.name),
+      properties,
+    }
+  }
+
+  /**
+   * @internal
+   *
+   * identifies lowercased headers provided by express that match those
+   * provided in the headerSchemas, and transforms the found keys to match
+   * those in the headerSchemas.
+   *
+   * @param headers - the headers provided by the request
+   * @param headerSchemas - the array of headers computed by the openapi endpoint renderer
+   * @returns the same headers object, but any headers matching those in the openapi schema are camelized
+   */
+  private camelizedOpenapiHeaders(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    headers: any,
+    headerSchemas: OpenapiParameterResponse[],
+  ) {
+    const headerSchemaMap = headerSchemas.reduce(
+      (agg, schema) => {
+        agg[schema.name.toLowerCase()] = schema
+        return agg
+      },
+      {} as Record<string, OpenapiParameterResponse>,
+    )
+
+    const camelizedHeaders = Object.keys((headers || {}) as object).reduce(
+      (agg, headerKey) => {
+        const matchingKey = headerSchemaMap[headerKey]?.name || headerKey
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        agg[matchingKey] = headers[headerKey]
+
+        return agg
+      },
+      {} as Record<string, unknown>,
+    )
+
+    return camelizedHeaders
+  }
+
+  /**
+   * @internal
+   *
+   * validates a provided data against the provided openapiSchema.
+   * If validation fails, OpenapiValidationFailure will be raised,
+   * which is automatically handled by psychic and turned into a 400
+   * with the respective errors attached.
+   *
+   * @param headers - the request headers
+   */
+  private validateOrFail(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    data: any,
+    openapiSchema: object,
+    target: OpenapiValidateTarget,
+  ) {
+    const validationResults = validateOpenApiSchema(
+      data || {},
+      this.addComponentsToSchema(openapiSchema),
+      this.getAjvOptions(),
+    )
+
+    if (!validationResults.isValid) {
+      const errorClass =
+        target === 'responseBody' ? OpenapiResponseValidationFailure : OpenapiRequestValidationFailure
+      throw new errorClass(validationResults.errors || [], target)
+    }
+  }
+
+  /**
+   * @internal
+   *
+   * Takes a schema and adds all of the missing components
+   * that may or may not be needed to evaluate the schema provided.
+   * This intervention is necessary, since controller openapi
+   * specs can reference schema components that aren't defined
+   * within the openapi decorators used in that controller.
+   *
+   * @param schema - the schema you want components to be added to
+   * @returns an object which contains the original schema, as well as the merged components found in the corresponding openapi file
+   */
+  private addComponentsToSchema<T>(schema: T): T {
+    const correspondingOpenapiFileData = PsychicApp.getOrFail().getOpenapiFileOrFail(this.openapiName)
+
+    return {
+      ...schema,
+      components: correspondingOpenapiFileData?.components,
+    }
+  }
+
+  /**
+   * @internal
+   *
+   * validates a provided data against the provided openapiSchema.
+   * If validation fails, OpenapiValidationFailure will be raised,
+   * which is automatically handled by psychic and turned into a 400
+   * with the respective errors attached.
+   */
+  private getAjvOptions(): ValidateOpenapiSchemaOptions {
+    const rendererOpts = this.openapiEndpointRenderer['validate']?.['ajvOptions']
+    const openapiConf = PsychicApp.getOrFail().openapi?.[this.openapiName]
+    return {
+      ...openapiConf?.validate?.ajvOptions,
+      ...rendererOpts,
+    }
+  }
+}

--- a/src/psychic-app/cache.ts
+++ b/src/psychic-app/cache.ts
@@ -1,3 +1,4 @@
+import MustCallPsychicAppInitFirst from '../error/psychic-app/must-call-psychic-app-init-first.js'
 import PsychicApp from './index.js'
 
 let _psychicApp: PsychicApp | undefined = undefined
@@ -11,6 +12,6 @@ export function getCachedPsychicApp() {
 }
 
 export function getCachedPsychicAppOrFail() {
-  if (!_psychicApp) throw new Error('must call `cachePsychicApp` before loading cached psychic app')
+  if (!_psychicApp) throw new MustCallPsychicAppInitFirst()
   return _psychicApp
 }

--- a/src/psychic-app/openapi-cache.ts
+++ b/src/psychic-app/openapi-cache.ts
@@ -1,0 +1,62 @@
+import * as fs from 'node:fs/promises'
+import openapiJsonPath from '../helpers/openapiJsonPath.js'
+import MustCallPsychicAppInitFirst from '../error/psychic-app/must-call-psychic-app-init-first.js'
+const _openapiData: Record<string, OpenapiShell | typeof FILE_DOES_NOT_EXIST> = {}
+
+/**
+ * we only cache the components from the openapi files,
+ * since that is all that we currently need for validation,
+ * which is the only thing leveraging these cached openapi files.
+ */
+export interface OpenapiShell {
+  components: {
+    schemas: object
+  }
+}
+
+/**
+ * Raises an exception if readAndCacheOpenapiFile was not called
+ * first, since this is a requisite to returning the scanned file.
+ *
+ * @param openapiName - the openapiName you wish to look up
+ * @returns the cached openapi file, or undefined if it was not found
+ */
+export function getOpenapiFileOrFail(openapiName: string) {
+  const val = _openapiData[openapiName]
+  if (!val) throw new MustCallPsychicAppInitFirst()
+  if (val === FILE_DOES_NOT_EXIST) return undefined
+  return val
+}
+
+/**
+ * Reads the openapi file corresponding to the openapiName,
+ * and caches its contents, enabling them to be read back
+ * at a later time, such as during endpoint validation.
+ *
+ * This function is called during PsychicApp.init sequence automatically.
+ *
+ * @param openapiName - the openapiName you wish to look up
+ */
+export async function readAndCacheOpenapiFile(openapiName: string): Promise<void> {
+  if (_openapiData[openapiName]) return
+
+  // if the openapi file is not generated yet, we don't want to raise an
+  // exception, so we will simply consider this file as undefined.
+  try {
+    const buffer = await fs.readFile(openapiJsonPath(openapiName))
+
+    const openapiDoc = JSON.parse(buffer.toString()) as OpenapiShell
+
+    //  we only cache the components from the openapi files,
+    //  since that is all that we currently need for validation,
+    //  which is the only thing leveraging these cached openapi files.
+    _openapiData[openapiName] = openapiDoc?.components
+      ? { components: openapiDoc.components }
+      : FILE_DOES_NOT_EXIST
+  } catch {
+    _openapiData[openapiName] = FILE_DOES_NOT_EXIST
+    // noop
+  }
+}
+
+const FILE_DOES_NOT_EXIST = 'FILE_DOES_NOT_EXIST'

--- a/src/router/helpers.ts
+++ b/src/router/helpers.ts
@@ -5,8 +5,9 @@ import CannotInferControllerFromTopLevelRouteError from '../error/router/cannot-
 import pascalizeFileName from '../helpers/pascalizeFileName.js'
 import { FunctionPropertyNames } from '../helpers/typeHelpers.js'
 import PsychicApp from '../psychic-app/index.js'
-import PsychicRouter, { PsychicNestedRouter } from '../router/index.js'
+import PsychicRouter from '../router/index.js'
 import { HttpMethod, ResourcesMethodType, ResourcesOptions } from './types.js'
+import PsychicRouteComputer from './route-computer.js'
 
 export function routePath(routePath: string) {
   return `/${routePath.replace(/^\//, '')}`
@@ -42,7 +43,7 @@ export function namespacedControllerActionString(namespace: string, controllerAc
     .replace(/^\//, '')
 }
 
-type RoutingMechanism = PsychicRouter | PsychicNestedRouter
+type RoutingMechanism = PsychicRouter | PsychicRouteComputer
 
 type LookupOpts = {
   resourceName?: string
@@ -154,7 +155,7 @@ export function applyResourcesAction(
 export function applyResourceAction(
   path: string,
   action: ResourcesMethodType,
-  routingMechanism: PsychicRouter | PsychicNestedRouter,
+  routingMechanism: RoutingMechanism,
   options?: ResourcesOptions,
 ) {
   const controller =

--- a/src/router/route-computer.ts
+++ b/src/router/route-computer.ts
@@ -1,0 +1,360 @@
+import { camelize } from '@rvoh/dream'
+import { RequestHandler, Router } from 'express'
+import pluralize from 'pluralize-esm'
+import PsychicController from '../controller/index.js'
+import PsychicApp from '../psychic-app/index.js'
+import {
+  NamespaceConfig,
+  PsychicControllerActions,
+  applyResourceAction,
+  applyResourcesAction,
+  convertRouteParams,
+  lookupControllerOrFail,
+} from './helpers.js'
+import RouteManager from './route-manager.js'
+import {
+  HttpMethod,
+  ResourceMethods,
+  ResourcesMethodType,
+  ResourcesMethods,
+  ResourcesOptions,
+} from './types.js'
+
+export default class PsychicRouteComputer {
+  public config: PsychicApp
+  public currentNamespaces: NamespaceConfig[] = []
+  public routeManager: RouteManager = new RouteManager()
+  constructor(config: PsychicApp) {
+    this.config = config
+  }
+
+  public get routes() {
+    return this.routeManager.routes
+  }
+
+  private get currentNamespacePaths() {
+    return this.currentNamespaces.map(n => n.namespace)
+  }
+
+  get(path: string): void
+  get(path: string, middleware: RequestHandler | RequestHandler[]): void
+  get<T extends typeof PsychicController>(
+    path: string,
+    controller: T,
+    action: PsychicControllerActions<T>,
+  ): void
+  get(path: string, controller?: unknown, action?: unknown) {
+    this.crud('get', path, controller as typeof PsychicController, action as string)
+  }
+
+  post(path: string): void
+  post(path: string, middleware: RequestHandler | RequestHandler[]): void
+  post<T extends typeof PsychicController>(
+    path: string,
+    controller: T,
+    action: PsychicControllerActions<T>,
+  ): void
+  post<T extends typeof PsychicController>(
+    path: string,
+    controller?: T,
+    action?: PsychicControllerActions<T>,
+  ) {
+    this.crud('post', path, controller as typeof PsychicController, action as string)
+  }
+
+  put(path: string): void
+  put(path: string, middleware: RequestHandler | RequestHandler[]): void
+  put<T extends typeof PsychicController>(
+    path: string,
+    controller: T,
+    action: PsychicControllerActions<T>,
+  ): void
+  put<T extends typeof PsychicController>(
+    path: string,
+    controller?: T,
+    action?: PsychicControllerActions<T>,
+  ) {
+    this.crud('put', path, controller as typeof PsychicController, action as string)
+  }
+
+  patch(path: string): void
+  patch(path: string, middleware: RequestHandler | RequestHandler[]): void
+  patch<T extends typeof PsychicController>(
+    path: string,
+    controller: T,
+    action: PsychicControllerActions<T>,
+  ): void
+  patch<T extends typeof PsychicController>(
+    path: string,
+    controller?: T,
+    action?: PsychicControllerActions<T>,
+  ) {
+    this.crud('patch', path, controller as typeof PsychicController, action as string)
+  }
+
+  delete(path: string): void
+  delete(path: string, middleware: RequestHandler | RequestHandler[]): void
+  delete<T extends typeof PsychicController>(
+    path: string,
+    controller: T,
+    action: PsychicControllerActions<T>,
+  ): void
+  delete<T extends typeof PsychicController>(
+    path: string,
+    controller?: T,
+    action?: PsychicControllerActions<T>,
+  ) {
+    this.crud('delete', path, controller as typeof PsychicController, action as string)
+  }
+
+  options(path: string): void
+  options(path: string, middleware: RequestHandler | RequestHandler[]): void
+  options<T extends typeof PsychicController>(
+    path: string,
+    controller: T,
+    action: PsychicControllerActions<T>,
+  ): void
+  options<T extends typeof PsychicController>(
+    path: string,
+    controller?: T,
+    action?: PsychicControllerActions<T>,
+  ) {
+    this.crud('options', path, controller as typeof PsychicController, action as string)
+  }
+
+  private prefixPathWithNamespaces(str: string) {
+    if (!this.currentNamespaces.length) return str
+    return '/' + this.currentNamespacePaths.join('/') + '/' + str
+  }
+
+  public crud(httpMethod: HttpMethod, path: string): void
+  public crud(httpMethod: HttpMethod, path: string, middleware: RequestHandler | RequestHandler[]): void
+  public crud(
+    httpMethod: HttpMethod,
+    path: string,
+    controller: typeof PsychicController,
+    action: string,
+  ): void
+  public crud(httpMethod: HttpMethod, path: string, controllerOrMiddleware?: unknown, action?: string) {
+    this.checkPathForInvalidChars(path)
+
+    const isMiddleware =
+      (typeof controllerOrMiddleware === 'function' || Array.isArray(controllerOrMiddleware)) &&
+      !(controllerOrMiddleware as typeof PsychicController)?.isPsychicController
+
+    // devs can provide custom express middleware which bypasses
+    // the normal Controller#action paradigm.
+    if (isMiddleware) {
+      this.routeManager.addMiddleware({
+        httpMethod,
+        path: this.prefixPathWithNamespaces(path),
+        middleware: controllerOrMiddleware as RequestHandler | RequestHandler[],
+      })
+    } else {
+      controllerOrMiddleware ||= lookupControllerOrFail(this, { path, httpMethod })
+      action ||= path.replace(/^\//, '')
+      if (action.match(/\//))
+        throw new Error('action cant have a slash in it - action was inferred from path')
+
+      this.routeManager.addRoute({
+        httpMethod,
+        path: this.prefixPathWithNamespaces(path),
+        controller: controllerOrMiddleware as typeof PsychicController,
+        action,
+      })
+    }
+  }
+
+  private checkPathForInvalidChars(path: string) {
+    if (path.includes('{'))
+      throw new Error(`
+The provided route "${path}" contains characters that are not supported.
+If you are trying to write a uri param, you will need to use expressjs
+param syntax, which is a prefixing colon, rather than using brackets
+to surround the param.
+
+provided route: "${path}"
+suggested fix:  "${convertRouteParams(path)}"
+`)
+  }
+
+  public namespace(namespace: string, cb: (router: PsychicNestedRouteComputer) => void) {
+    const nestedRouter = new PsychicNestedRouteComputer(this.config, this.routeManager, {
+      namespaces: this.currentNamespaces,
+    })
+
+    this.runNestedCallbacks(namespace, nestedRouter, cb)
+  }
+
+  public scope(scope: string, cb: (router: PsychicNestedRouteComputer) => void) {
+    const nestedRouter = new PsychicNestedRouteComputer(this.config, this.routeManager, {
+      namespaces: this.currentNamespaces,
+    })
+
+    this.runNestedCallbacks(scope, nestedRouter, cb, { treatNamespaceAsScope: true })
+  }
+
+  public resources(
+    path: string,
+    optionsOrCb?: ResourcesOptions | ((router: PsychicNestedRouteComputer) => void),
+    cb?: (router: PsychicNestedRouteComputer) => void,
+  ) {
+    return this.makeResource(path, optionsOrCb, cb, true)
+  }
+
+  public resource(
+    path: string,
+    optionsOrCb?: ResourcesOptions | ((router: PsychicNestedRouteComputer) => void),
+    cb?: (router: PsychicNestedRouteComputer) => void,
+  ) {
+    return this.makeResource(path, optionsOrCb, cb, false)
+  }
+
+  public collection(cb: (router: PsychicNestedRouteComputer) => void) {
+    const replacedNamespaces = this.currentNamespaces.slice(0, this.currentNamespaces.length - 1)
+    const nestedRouter = new PsychicNestedRouteComputer(this.config, this.routeManager, {
+      namespaces: replacedNamespaces,
+    })
+    const currentNamespace = replacedNamespaces[replacedNamespaces.length - 1]
+    if (!currentNamespace)
+      throw new Error('Must be within a `resources` declaration to call the collection method')
+
+    cb(nestedRouter)
+  }
+
+  private makeResource(
+    path: string,
+    optionsOrCb: ResourcesOptions | ((router: PsychicNestedRouteComputer) => void) | undefined,
+    cb: ((router: PsychicNestedRouteComputer) => void) | undefined,
+    plural: boolean,
+  ) {
+    if (cb) {
+      if (typeof optionsOrCb === 'function')
+        throw new Error('cannot pass a function as a second arg when passing 3 args')
+      this._makeResource(path, optionsOrCb as ResourcesOptions, cb, plural)
+    } else {
+      if (typeof optionsOrCb === 'function') this._makeResource(path, undefined, optionsOrCb, plural)
+      else this._makeResource(path, optionsOrCb, undefined, plural)
+    }
+  }
+
+  private _makeResource(
+    path: string,
+    options: ResourcesOptions | undefined,
+    cb: ((router: PsychicNestedRouteComputer) => void) | undefined,
+    plural: boolean,
+  ) {
+    const nestedRouter = new PsychicNestedRouteComputer(this.config, this.routeManager, {
+      namespaces: this.currentNamespaces,
+    })
+
+    const { only, except } = options || {}
+    let resourceMethods: ResourcesMethodType[] = plural ? ResourcesMethods : ResourceMethods
+
+    if (only) {
+      resourceMethods = only
+    } else if (except) {
+      resourceMethods = resourceMethods.filter(m => !except.includes(m))
+    }
+
+    const originalCurrentNamespaces = this.currentNamespaces
+    this.makeRoomForNewIdParam(nestedRouter)
+    this.runNestedCallbacks(path, nestedRouter, cb, { asMember: plural, resourceful: true })
+    this.currentNamespaces = originalCurrentNamespaces
+
+    resourceMethods.forEach(action => {
+      if (plural) {
+        applyResourcesAction(path, action, nestedRouter, options)
+      } else {
+        applyResourceAction(path, action, nestedRouter, options)
+      }
+    })
+  }
+
+  private runNestedCallbacks(
+    namespace: string,
+    nestedRouter: PsychicNestedRouteComputer,
+    cb?: (router: PsychicNestedRouteComputer) => void,
+    {
+      asMember = false,
+      resourceful = false,
+      treatNamespaceAsScope = false,
+    }: {
+      asMember?: boolean
+      resourceful?: boolean
+      treatNamespaceAsScope?: boolean
+    } = {},
+  ) {
+    this.addNamespace(namespace, resourceful, { nestedRouter, treatNamespaceAsScope })
+
+    if (asMember) {
+      this.addNamespace(':id', resourceful, { nestedRouter, treatNamespaceAsScope: true })
+    }
+
+    if (cb) cb(nestedRouter)
+
+    this.removeLastNamespace(nestedRouter)
+    if (asMember) this.removeLastNamespace(nestedRouter)
+  }
+
+  private addNamespace(
+    namespace: string,
+    resourceful: boolean,
+    {
+      nestedRouter,
+      treatNamespaceAsScope,
+    }: {
+      nestedRouter?: PsychicNestedRouteComputer
+      treatNamespaceAsScope?: boolean
+    } = {},
+  ) {
+    this.currentNamespaces = [
+      ...this.currentNamespaces,
+      {
+        namespace,
+        resourceful,
+        isScope: treatNamespaceAsScope || false,
+      },
+    ]
+
+    if (nestedRouter) nestedRouter.currentNamespaces = this.currentNamespaces
+  }
+
+  private removeLastNamespace(nestedRouter?: PsychicNestedRouteComputer) {
+    this.currentNamespaces.pop()
+    if (nestedRouter) nestedRouter.currentNamespaces = this.currentNamespaces
+  }
+
+  private makeRoomForNewIdParam(nestedRouter?: PsychicNestedRouteComputer) {
+    this.currentNamespaces = [
+      ...this.currentNamespaces.map((namespace, index) => {
+        const previousNamespace = this.currentNamespaces[index - 1]
+        if (namespace.namespace === ':id' && previousNamespace) {
+          return {
+            ...namespace,
+            namespace: `:${camelize(pluralize.singular(previousNamespace.namespace))}Id`,
+          }
+        } else return namespace
+      }),
+    ]
+    if (nestedRouter) nestedRouter.currentNamespaces = this.currentNamespaces
+  }
+}
+
+export class PsychicNestedRouteComputer extends PsychicRouteComputer {
+  public router: Router
+  constructor(
+    config: PsychicApp,
+    routeManager: RouteManager,
+    {
+      namespaces = [],
+    }: {
+      namespaces?: NamespaceConfig[]
+    } = {},
+  ) {
+    super(config)
+    this.router = Router()
+    this.currentNamespaces = namespaces
+    this.routeManager = routeManager
+  }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -10,6 +10,7 @@ import startPsychicServer, {
   createPsychicHttpInstance,
   StartPsychicServerOptions,
 } from './helpers/startPsychicServer.js'
+import EnvInternal from '../helpers/EnvInternal.js'
 
 // const debugEnabled = debuglog('psychic').enabled
 
@@ -49,6 +50,8 @@ export default class PsychicServer {
 
     const psychicApp = PsychicApp.getOrFail()
 
+    this.setSecureDefaultHeaders()
+
     this.expressApp.use((_, res, next) => {
       Object.keys(psychicApp.defaultResponseHeaders).forEach(key => {
         res.setHeader(key, psychicApp.defaultResponseHeaders[key]!)
@@ -86,6 +89,19 @@ export default class PsychicServer {
 
     this.booted = true
     return true
+  }
+
+  private setSecureDefaultHeaders() {
+    this.expressApp.disable('x-powered-by')
+
+    this.expressApp.use((_, res, next) => {
+      res.setHeader('X-Content-Type-Options', 'nosniff')
+
+      if (EnvInternal.isProduction) {
+        res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains')
+      }
+      next()
+    })
   }
 
   // TODO: use config helper for fetching default port

--- a/test-app/src/app/controllers/OpenapiValidationTestsController.ts
+++ b/test-app/src/app/controllers/OpenapiValidationTestsController.ts
@@ -1,0 +1,232 @@
+import EnvInternal from '../../../../src/helpers/EnvInternal.js'
+import { OpenAPI } from '../../../../src/index.js'
+import ApplicationController from './ApplicationController.js'
+
+export default class OpenapiValidationTestsController extends ApplicationController {
+  @OpenAPI({
+    status: 200,
+    requestBody: {
+      type: 'object',
+      properties: {
+        numericParam: 'number',
+      },
+    },
+  })
+  public invalidRequestBody() {
+    this.ok()
+  }
+
+  @OpenAPI({
+    status: 204,
+    requestBody: {
+      type: 'object',
+      required: ['requiredInt'],
+      properties: {
+        requiredInt: 'integer',
+        optionalInt: 'integer',
+      },
+    },
+  })
+  public requestBodyOpenapiTest() {
+    this.noContent()
+  }
+
+  @OpenAPI({
+    status: 200,
+    requestBody: {
+      type: 'object',
+      required: ['nested'],
+      properties: {
+        nested: {
+          type: 'object',
+          required: ['object'],
+          properties: {
+            object: {
+              type: 'object',
+              required: ['requiredInt'],
+              properties: {
+                requiredInt: 'integer',
+                optionalInt: 'integer',
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+  public requestBodyNestedObjectOpenapiTest() {
+    this.noContent()
+  }
+
+  @OpenAPI({
+    status: 200,
+    query: {
+      stringParam: {
+        required: false,
+        schema: {
+          type: 'string',
+        },
+      },
+      numericParam: {
+        required: false,
+        schema: {
+          type: 'number',
+        },
+      },
+      stringArray: {
+        required: false,
+        schema: {
+          type: 'string[]',
+        },
+      },
+    },
+  })
+  public queryOpenapiTest() {
+    this.ok({
+      stringParam: this.params.stringParam,
+      numericParam: this.params.numericParam,
+      stringArray: this.params.stringArray,
+    })
+  }
+
+  @OpenAPI({
+    status: 200,
+    query: {
+      requiredStringParam: {
+        required: true,
+        schema: {
+          type: 'string',
+        },
+      },
+      nonRequiredStringParam: {
+        required: false,
+        schema: {
+          type: 'string',
+        },
+      },
+    },
+    validate: {
+      ajvOptions: {
+        allErrors: EnvInternal.isTest,
+      },
+    },
+  })
+  public queryRequiredOpenapiTest() {
+    this.ok()
+  }
+
+  @OpenAPI({
+    status: 200,
+    responses: {
+      200: {
+        type: 'number',
+      },
+    },
+  })
+  public responseBodyOpenapiTest() {
+    this.ok(this.params.renderMe)
+  }
+
+  @OpenAPI({
+    status: 200,
+    responses: {
+      200: {
+        type: 'object',
+        required: ['nested'],
+        properties: {
+          nested: {
+            type: 'object',
+            required: ['object'],
+            properties: {
+              object: {
+                type: 'object',
+                required: ['requiredInt'],
+                properties: {
+                  requiredInt: 'integer',
+                  optionalInt: 'integer',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+  public responseBodyNestedObjectOpenapiTest() {
+    this.ok({
+      nested: {
+        object: {
+          requiredInt: this.params.requiredInt,
+          optionalInt: this.params.optionalInt,
+        },
+      },
+    })
+  }
+
+  @OpenAPI({
+    status: 200,
+    responses: {
+      200: {
+        type: 'object',
+        required: ['requiredInt'],
+        properties: {
+          requiredInt: 'integer',
+          optionalInt: 'integer',
+        },
+      },
+    },
+  })
+  public responseBodyObjectOpenapiTest() {
+    this.ok({
+      requiredInt: this.params.requiredInt,
+      optionalInt: this.params.optionalInt,
+    })
+  }
+
+  @OpenAPI({
+    status: 200,
+    headers: {
+      myDate: {
+        required: true,
+        format: 'date',
+      },
+      myOptionalDate: {
+        required: false,
+        format: 'date',
+      },
+      myOptionalInt: {
+        required: false,
+        schema: {
+          type: 'integer',
+        },
+      },
+    },
+    validate: {
+      ajvOptions: {
+        allErrors: EnvInternal.isTest,
+      },
+    },
+  })
+  public headersOpenapiTest() {
+    this.ok({
+      myDate: this.req.headers.mydate,
+      myOptionalDate: this.req.headers.myoptionaldate,
+      myOptionalInt: this.req.headers.myoptionalint,
+    })
+  }
+
+  @OpenAPI({
+    status: 200,
+    responses: {
+      200: {
+        type: 'number',
+      },
+      401: {
+        type: 'number',
+      },
+    },
+  })
+  public responseAlternateStatusTest() {
+    this.unauthorized(12345)
+  }
+}

--- a/test-app/src/app/controllers/PetsController.ts
+++ b/test-app/src/app/controllers/PetsController.ts
@@ -30,7 +30,7 @@ export default class PetsController extends ApplicationController {
   }
 
   private get petParams() {
-    return this.paramsFor(Pet)
+    return this.paramsFor(Pet, { including: ['userId'] })
   }
 
   @OpenAPI(Post, {

--- a/test-app/src/app/controllers/ResponseStatusesController.ts
+++ b/test-app/src/app/controllers/ResponseStatusesController.ts
@@ -7,6 +7,16 @@ export default class ResponseStatusesController extends ApplicationController {
     this.ok('custom content')
   }
 
+  // 200
+  public sendOkNull() {
+    this.ok(null)
+  }
+
+  // 200
+  public sendOkUndefined() {
+    this.ok(undefined)
+  }
+
   // 201
   public sendCreated() {
     this.created('custom content')

--- a/test-app/src/conf/app.ts
+++ b/test-app/src/conf/app.ts
@@ -81,7 +81,7 @@ export default async (psy: PsychicApp) => {
     defaults: {
       headers: {
         ['custom-header']: {
-          required: true,
+          required: false,
           description: 'custom header',
         },
       },

--- a/test-app/src/conf/dream.ts
+++ b/test-app/src/conf/dream.ts
@@ -1,3 +1,4 @@
+import { debuglog } from 'node:util'
 import { DreamApp } from '@rvoh/dream'
 import importAll from '../app/helpers/importAll.js'
 import importDefault from '../app/helpers/importDefault.js'
@@ -33,5 +34,24 @@ export default async function configureDream(app: DreamApp) {
       port: parseInt(process.env.DB_PORT!),
       useSsl: process.env.DB_USE_SSL === '1',
     },
+  })
+
+  app.on('db:log', event => {
+    if (!debuglog('sql').enabled) return
+
+    if (event.level === 'error') {
+      console.error('the following db query encountered an unexpected error: ', {
+        durationMs: event.queryDurationMillis,
+        error: event.error,
+        sql: event.query.sql,
+        params: event.query.parameters,
+      })
+    } else {
+      console.log('db query completed:', {
+        durationMs: event.queryDurationMillis,
+        sql: event.query.sql,
+        params: event.query.parameters,
+      })
+    }
   })
 }

--- a/test-app/src/conf/routes.ts
+++ b/test-app/src/conf/routes.ts
@@ -17,6 +17,7 @@ import ScopeTestController from '../app/controllers/ScopeTestController.js'
 import UnauthedUsersController from '../app/controllers/UnauthedUsersController.js'
 import UsersController from '../app/controllers/UsersController.js'
 import User from '../app/models/User.js'
+import OpenapiValidationTestsController from '../app/controllers/OpenapiValidationTestsController.js'
 
 export default (r: PsychicRouter) => {
   r.get('circular', CircularController, 'hello')
@@ -64,6 +65,25 @@ export default (r: PsychicRouter) => {
     r.post('my-posts', PetsController, 'myPosts')
   })
 
+  r.get('queryOpenapiTest', OpenapiValidationTestsController, 'queryOpenapiTest')
+  r.get('queryRequiredOpenapiTest', OpenapiValidationTestsController, 'queryRequiredOpenapiTest')
+  r.get('responseBodyOpenapiTest', OpenapiValidationTestsController, 'responseBodyOpenapiTest')
+  r.get('responseBodyObjectOpenapiTest', OpenapiValidationTestsController, 'responseBodyObjectOpenapiTest')
+  r.get(
+    'responseBodyNestedObjectOpenapiTest',
+    OpenapiValidationTestsController,
+    'responseBodyNestedObjectOpenapiTest',
+  )
+  r.get('responseAlternateStatusTest', OpenapiValidationTestsController, 'responseAlternateStatusTest')
+  r.get('headersOpenapiTest', OpenapiValidationTestsController, 'headersOpenapiTest')
+  r.post('requestBodyOpenapiTest', OpenapiValidationTestsController, 'requestBodyOpenapiTest')
+  r.post(
+    'requestBodyNestedObjectOpenapiTest',
+    OpenapiValidationTestsController,
+    'requestBodyNestedObjectOpenapiTest',
+  )
+  r.post('invalidRequestBody', OpenapiValidationTestsController, 'invalidRequestBody')
+
   // hooks tests
   r.get('users-before-all-test', UsersController, 'beforeAllTest')
   r.get('users-before-action-sequence', UsersController, 'beforeActionSequence')
@@ -74,6 +94,8 @@ export default (r: PsychicRouter) => {
   // response status tests
   // 2xx series
   r.get('ok', ResponseStatusesController, 'sendOk') // 200
+  r.get('ok-null', ResponseStatusesController, 'sendOkNull') // 200
+  r.get('ok-undefined', ResponseStatusesController, 'sendOkUndefined') // 200
   r.get('created', ResponseStatusesController, 'sendCreated') // 201
   r.get('accepted', ResponseStatusesController, 'sendAccepted') // 202
   r.get('non-authoritative-information', ResponseStatusesController, 'sendNonAuthoritativeInformation') // 203

--- a/test-app/src/openapi/admin.openapi.json
+++ b/test-app/src/openapi/admin.openapi.json
@@ -215,11 +215,18 @@
         "description": "The request has succeeded, but there is no content to render"
       },
       "BadRequest": {
-        "description": "The server would not process the request due to something the server considered to be a client error",
+        "description": "The server would not process the request due to something the server considered to be a client error, such as a model validation failure or an openapi validation failure",
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/ValidationErrors"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ValidationErrors"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenapiValidationErrors"
+                }
+              ]
             }
           }
         }
@@ -291,9 +298,74 @@
       "CustomAdminSchema": {
         "type": "string"
       },
+      "OpenapiValidationErrors": {
+        "type": "object",
+        "required": [
+          "type",
+          "target",
+          "errors"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "openapi"
+            ]
+          },
+          "target": {
+            "type": "string",
+            "enum": [
+              "requestBody",
+              "query",
+              "headers",
+              "responseBody"
+            ]
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "instancePath",
+                "schemaPath",
+                "keyword",
+                "message",
+                "params"
+              ],
+              "properties": {
+                "instancePath": {
+                  "type": "string"
+                },
+                "schemaPath": {
+                  "type": "string"
+                },
+                "keyword": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "params": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      },
       "ValidationErrors": {
         "type": "object",
+        "required": [
+          "type",
+          "errors"
+        ],
         "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "validation"
+            ]
+          },
           "errors": {
             "type": "object",
             "additionalProperties": {

--- a/test-app/src/openapi/mobile.openapi.json
+++ b/test-app/src/openapi/mobile.openapi.json
@@ -147,9 +147,74 @@
           }
         }
       },
+      "OpenapiValidationErrors": {
+        "type": "object",
+        "required": [
+          "type",
+          "target",
+          "errors"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "openapi"
+            ]
+          },
+          "target": {
+            "type": "string",
+            "enum": [
+              "requestBody",
+              "query",
+              "headers",
+              "responseBody"
+            ]
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "instancePath",
+                "schemaPath",
+                "keyword",
+                "message",
+                "params"
+              ],
+              "properties": {
+                "instancePath": {
+                  "type": "string"
+                },
+                "schemaPath": {
+                  "type": "string"
+                },
+                "keyword": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "params": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      },
       "ValidationErrors": {
         "type": "object",
+        "required": [
+          "type",
+          "errors"
+        ],
         "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "validation"
+            ]
+          },
           "errors": {
             "type": "object",
             "additionalProperties": {
@@ -167,11 +232,18 @@
         "description": "The request has succeeded, but there is no content to render"
       },
       "BadRequest": {
-        "description": "The server would not process the request due to something the server considered to be a client error",
+        "description": "The server would not process the request due to something the server considered to be a client error, such as a model validation failure or an openapi validation failure",
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/ValidationErrors"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ValidationErrors"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenapiValidationErrors"
+                }
+              ]
             }
           }
         }

--- a/test-app/src/openapi/openapi.json
+++ b/test-app/src/openapi/openapi.json
@@ -11,7 +11,7 @@
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -66,7 +66,7 @@
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -123,7 +123,7 @@
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -555,7 +555,7 @@
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -995,7 +995,7 @@
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -1060,7 +1060,7 @@
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -1130,7 +1130,7 @@
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -1198,7 +1198,7 @@
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -1269,7 +1269,7 @@
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -1324,7 +1324,7 @@
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -1374,12 +1374,151 @@
         }
       }
     },
+    "/headersOpenapiTest": {
+      "parameters": [
+        {
+          "in": "header",
+          "name": "custom-header",
+          "required": false,
+          "description": "custom header",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "in": "header",
+          "name": "myDate",
+          "required": true,
+          "description": "myDate",
+          "schema": {
+            "type": "string",
+            "format": "date"
+          }
+        },
+        {
+          "in": "header",
+          "name": "myOptionalDate",
+          "required": false,
+          "description": "myOptionalDate",
+          "schema": {
+            "type": "string",
+            "format": "date"
+          }
+        },
+        {
+          "in": "header",
+          "name": "myOptionalInt",
+          "required": false,
+          "description": "myOptionalInt",
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "418": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationErrors"
+          },
+          "490": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/invalidRequestBody": {
+      "parameters": [
+        {
+          "in": "header",
+          "name": "custom-header",
+          "required": false,
+          "description": "custom header",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "tags": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "numericParam": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "418": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationErrors"
+          },
+          "490": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
     "/openapi-validation-on-explicit-query-arrays": {
       "parameters": [
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -1441,7 +1580,7 @@
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -1503,7 +1642,7 @@
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -1583,7 +1722,7 @@
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -1746,7 +1885,7 @@
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -1911,7 +2050,7 @@
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -1980,12 +2119,579 @@
         }
       }
     },
+    "/queryOpenapiTest": {
+      "parameters": [
+        {
+          "in": "header",
+          "name": "custom-header",
+          "required": false,
+          "description": "custom header",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "in": "query",
+          "name": "stringParam",
+          "description": "stringParam",
+          "allowReserved": true,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "in": "query",
+          "name": "numericParam",
+          "description": "numericParam",
+          "allowReserved": true,
+          "required": false,
+          "schema": {
+            "type": "number"
+          }
+        },
+        {
+          "in": "query",
+          "name": "stringArray",
+          "description": "stringArray",
+          "allowReserved": true,
+          "required": false,
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "418": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationErrors"
+          },
+          "490": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/queryRequiredOpenapiTest": {
+      "parameters": [
+        {
+          "in": "header",
+          "name": "custom-header",
+          "required": false,
+          "description": "custom header",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "in": "query",
+          "name": "requiredStringParam",
+          "description": "requiredStringParam",
+          "allowReserved": true,
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "in": "query",
+          "name": "nonRequiredStringParam",
+          "description": "nonRequiredStringParam",
+          "allowReserved": true,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "418": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationErrors"
+          },
+          "490": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/requestBodyNestedObjectOpenapiTest": {
+      "parameters": [
+        {
+          "in": "header",
+          "name": "custom-header",
+          "required": false,
+          "description": "custom header",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "tags": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "nested"
+                ],
+                "properties": {
+                  "nested": {
+                    "type": "object",
+                    "required": [
+                      "object"
+                    ],
+                    "properties": {
+                      "object": {
+                        "type": "object",
+                        "required": [
+                          "requiredInt"
+                        ],
+                        "properties": {
+                          "requiredInt": {
+                            "type": "integer"
+                          },
+                          "optionalInt": {
+                            "type": "integer"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "418": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationErrors"
+          },
+          "490": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/requestBodyOpenapiTest": {
+      "parameters": [
+        {
+          "in": "header",
+          "name": "custom-header",
+          "required": false,
+          "description": "custom header",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "tags": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "requiredInt"
+                ],
+                "properties": {
+                  "requiredInt": {
+                    "type": "integer"
+                  },
+                  "optionalInt": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success, no content",
+            "$ref": "#/components/responses/NoContent"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "418": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationErrors"
+          },
+          "490": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/responseAlternateStatusTest": {
+      "parameters": [
+        {
+          "in": "header",
+          "name": "custom-header",
+          "required": false,
+          "description": "custom header",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "418": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationErrors"
+          },
+          "490": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/responseBodyNestedObjectOpenapiTest": {
+      "parameters": [
+        {
+          "in": "header",
+          "name": "custom-header",
+          "required": false,
+          "description": "custom header",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "nested"
+                  ],
+                  "properties": {
+                    "nested": {
+                      "type": "object",
+                      "required": [
+                        "object"
+                      ],
+                      "properties": {
+                        "object": {
+                          "type": "object",
+                          "required": [
+                            "requiredInt"
+                          ],
+                          "properties": {
+                            "requiredInt": {
+                              "type": "integer"
+                            },
+                            "optionalInt": {
+                              "type": "integer"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "418": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationErrors"
+          },
+          "490": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/responseBodyObjectOpenapiTest": {
+      "parameters": [
+        {
+          "in": "header",
+          "name": "custom-header",
+          "required": false,
+          "description": "custom header",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "requiredInt"
+                  ],
+                  "properties": {
+                    "requiredInt": {
+                      "type": "integer"
+                    },
+                    "optionalInt": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "418": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationErrors"
+          },
+          "490": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/responseBodyOpenapiTest": {
+      "parameters": [
+        {
+          "in": "header",
+          "name": "custom-header",
+          "required": false,
+          "description": "custom header",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "418": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationErrors"
+          },
+          "490": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
     "/users": {
       "parameters": [
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -2468,7 +3174,7 @@
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -2986,7 +3692,7 @@
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -3049,7 +3755,7 @@
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -3137,7 +3843,7 @@
         {
           "in": "header",
           "name": "custom-header",
-          "required": true,
+          "required": false,
           "description": "custom header",
           "schema": {
             "type": "string"
@@ -3611,11 +4317,18 @@
         "description": "The request has succeeded, but there is no content to render"
       },
       "BadRequest": {
-        "description": "The server would not process the request due to something the server considered to be a client error",
+        "description": "The server would not process the request due to something the server considered to be a client error, such as a model validation failure or an openapi validation failure",
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/ValidationErrors"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ValidationErrors"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenapiValidationErrors"
+                }
+              ]
             }
           }
         }
@@ -3781,6 +4494,61 @@
           },
           "latexOnlySummaryAttr": {
             "type": "string"
+          }
+        }
+      },
+      "OpenapiValidationErrors": {
+        "type": "object",
+        "required": [
+          "type",
+          "target",
+          "errors"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "openapi"
+            ]
+          },
+          "target": {
+            "type": "string",
+            "enum": [
+              "requestBody",
+              "query",
+              "headers",
+              "responseBody"
+            ]
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "instancePath",
+                "schemaPath",
+                "keyword",
+                "message",
+                "params"
+              ],
+              "properties": {
+                "instancePath": {
+                  "type": "string"
+                },
+                "schemaPath": {
+                  "type": "string"
+                },
+                "keyword": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "params": {
+                  "type": "object"
+                }
+              }
+            }
           }
         }
       },
@@ -3963,7 +4731,17 @@
       },
       "ValidationErrors": {
         "type": "object",
+        "required": [
+          "type",
+          "errors"
+        ],
         "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "validation"
+            ]
+          },
           "errors": {
             "type": "object",
             "additionalProperties": {

--- a/test-app/src/types/openapi/openapi.d.ts
+++ b/test-app/src/types/openapi/openapi.d.ts
@@ -2,9 +2,9 @@ export interface paths {
     "/api/pets": {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path?: never;
             cookie?: never;
@@ -14,9 +14,9 @@ export interface paths {
         post: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path?: never;
                 cookie?: never;
@@ -52,9 +52,9 @@ export interface paths {
     "/api/pets/{id}": {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path: {
                 id: string;
@@ -70,9 +70,9 @@ export interface paths {
         patch: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path: {
                     id: string;
@@ -99,9 +99,9 @@ export interface paths {
     "/api/users": {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path?: never;
             cookie?: never;
@@ -111,9 +111,9 @@ export interface paths {
         post: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path?: never;
                 cookie?: never;
@@ -210,9 +210,9 @@ export interface paths {
     "/api/users/{id}": {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path: {
                 id: string;
@@ -228,9 +228,9 @@ export interface paths {
         patch: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path: {
                     id: string;
@@ -325,9 +325,9 @@ export interface paths {
     "/balloons": {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path?: never;
             cookie?: never;
@@ -335,9 +335,9 @@ export interface paths {
         get: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path?: never;
                 cookie?: never;
@@ -375,9 +375,9 @@ export interface paths {
     "/balloons/{id}": {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path: {
                 id: string;
@@ -387,9 +387,9 @@ export interface paths {
         get: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path: {
                     id: string;
@@ -429,9 +429,9 @@ export interface paths {
     "/balloons/index-different-dreams": {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path?: never;
             cookie?: never;
@@ -439,9 +439,9 @@ export interface paths {
         get: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path?: never;
                 cookie?: never;
@@ -479,9 +479,9 @@ export interface paths {
     "/balloons/index-dreams-and-view-model": {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path?: never;
             cookie?: never;
@@ -489,9 +489,9 @@ export interface paths {
         get: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path?: never;
                 cookie?: never;
@@ -529,9 +529,9 @@ export interface paths {
     "/circular": {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path?: never;
             cookie?: never;
@@ -539,9 +539,9 @@ export interface paths {
         get: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path?: never;
                 cookie?: never;
@@ -579,9 +579,9 @@ export interface paths {
     "/greeter/justforspecs": {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path?: never;
             cookie?: never;
@@ -589,9 +589,9 @@ export interface paths {
         get: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path?: never;
                 cookie?: never;
@@ -626,15 +626,129 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/headersOpenapiTest": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description custom header */
+                "custom-header"?: string;
+                /** @description myDate */
+                myDate: string;
+                /** @description myOptionalDate */
+                myOptionalDate?: string;
+                /** @description myOptionalInt */
+                myOptionalInt?: number;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header: {
+                    /** @description custom header */
+                    "custom-header"?: string;
+                    /** @description myDate */
+                    myDate: string;
+                    /** @description myOptionalDate */
+                    myOptionalDate?: string;
+                    /** @description myOptionalInt */
+                    myOptionalInt?: number;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                400: components["responses"]["BadRequest"];
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                409: components["responses"]["Conflict"];
+                418: components["responses"]["CustomResponse"];
+                422: components["responses"]["ValidationErrors"];
+                490: components["responses"]["CustomResponse"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/invalidRequestBody": {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description custom header */
+                "custom-header"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /** @description custom header */
+                    "custom-header"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        numericParam?: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                400: components["responses"]["BadRequest"];
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                409: components["responses"]["Conflict"];
+                418: components["responses"]["CustomResponse"];
+                422: components["responses"]["ValidationErrors"];
+                490: components["responses"]["CustomResponse"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/openapi-validation-on-explicit-query-arrays": {
         parameters: {
             query?: {
                 /** @description myArray[] */
                 "myArray[]"?: string[];
             };
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path?: never;
             cookie?: never;
@@ -645,9 +759,9 @@ export interface paths {
                     /** @description myArray[] */
                     "myArray[]"?: string[];
                 };
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path?: never;
                 cookie?: never;
@@ -686,9 +800,9 @@ export interface paths {
                 /** @description myArray */
                 myArray?: string[];
             };
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path?: never;
             cookie?: never;
@@ -699,9 +813,9 @@ export interface paths {
                     /** @description myArray */
                     myArray?: string[];
                 };
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path?: never;
                 cookie?: never;
@@ -737,9 +851,9 @@ export interface paths {
     "/openapi-validation-test": {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path?: never;
             cookie?: never;
@@ -749,9 +863,9 @@ export interface paths {
         post: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path?: never;
                 cookie?: never;
@@ -824,9 +938,9 @@ export interface paths {
     "/pets": {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path?: never;
             cookie?: never;
@@ -836,9 +950,9 @@ export interface paths {
         post: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path?: never;
                 cookie?: never;
@@ -900,9 +1014,9 @@ export interface paths {
     "/pets/{id}": {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path: {
                 id: string;
@@ -918,9 +1032,9 @@ export interface paths {
         patch: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path: {
                     id: string;
@@ -973,9 +1087,9 @@ export interface paths {
     "/pets/{id}/my-posts": {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path: {
                 id: string;
@@ -987,9 +1101,9 @@ export interface paths {
         post: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path: {
                     id: string;
@@ -1023,12 +1137,241 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/users": {
+    "/queryOpenapiTest": {
+        parameters: {
+            query?: {
+                /** @description stringParam */
+                stringParam?: string;
+                /** @description numericParam */
+                numericParam?: number;
+                /** @description stringArray */
+                stringArray?: string[];
+            };
+            header?: {
+                /** @description custom header */
+                "custom-header"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    /** @description stringParam */
+                    stringParam?: string;
+                    /** @description numericParam */
+                    numericParam?: number;
+                    /** @description stringArray */
+                    stringArray?: string[];
+                };
+                header?: {
+                    /** @description custom header */
+                    "custom-header"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                400: components["responses"]["BadRequest"];
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                409: components["responses"]["Conflict"];
+                418: components["responses"]["CustomResponse"];
+                422: components["responses"]["ValidationErrors"];
+                490: components["responses"]["CustomResponse"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/queryRequiredOpenapiTest": {
+        parameters: {
+            query: {
+                /** @description requiredStringParam */
+                requiredStringParam: string;
+                /** @description nonRequiredStringParam */
+                nonRequiredStringParam?: string;
+            };
+            header?: {
+                /** @description custom header */
+                "custom-header"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query: {
+                    /** @description requiredStringParam */
+                    requiredStringParam: string;
+                    /** @description nonRequiredStringParam */
+                    nonRequiredStringParam?: string;
+                };
+                header?: {
+                    /** @description custom header */
+                    "custom-header"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                400: components["responses"]["BadRequest"];
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                409: components["responses"]["Conflict"];
+                418: components["responses"]["CustomResponse"];
+                422: components["responses"]["ValidationErrors"];
+                490: components["responses"]["CustomResponse"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/requestBodyNestedObjectOpenapiTest": {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /** @description custom header */
+                    "custom-header"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        nested: {
+                            object: {
+                                requiredInt: number;
+                                optionalInt?: number;
+                            };
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                400: components["responses"]["BadRequest"];
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                409: components["responses"]["Conflict"];
+                418: components["responses"]["CustomResponse"];
+                422: components["responses"]["ValidationErrors"];
+                490: components["responses"]["CustomResponse"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/requestBodyOpenapiTest": {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description custom header */
+                "custom-header"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /** @description custom header */
+                    "custom-header"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        requiredInt: number;
+                        optionalInt?: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Success, no content */
+                204: components["responses"]["NoContent"];
+                400: components["responses"]["BadRequest"];
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                409: components["responses"]["Conflict"];
+                418: components["responses"]["CustomResponse"];
+                422: components["responses"]["ValidationErrors"];
+                490: components["responses"]["CustomResponse"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/responseAlternateStatusTest": {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description custom header */
+                "custom-header"?: string;
             };
             path?: never;
             cookie?: never;
@@ -1036,9 +1379,227 @@ export interface paths {
         get: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": number;
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": number;
+                    };
+                };
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                409: components["responses"]["Conflict"];
+                418: components["responses"]["CustomResponse"];
+                422: components["responses"]["ValidationErrors"];
+                490: components["responses"]["CustomResponse"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/responseBodyNestedObjectOpenapiTest": {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description custom header */
+                "custom-header"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /** @description custom header */
+                    "custom-header"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            nested: {
+                                object: {
+                                    requiredInt: number;
+                                    optionalInt?: number;
+                                };
+                            };
+                        };
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                409: components["responses"]["Conflict"];
+                418: components["responses"]["CustomResponse"];
+                422: components["responses"]["ValidationErrors"];
+                490: components["responses"]["CustomResponse"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/responseBodyObjectOpenapiTest": {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description custom header */
+                "custom-header"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /** @description custom header */
+                    "custom-header"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            requiredInt: number;
+                            optionalInt?: number;
+                        };
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                409: components["responses"]["Conflict"];
+                418: components["responses"]["CustomResponse"];
+                422: components["responses"]["ValidationErrors"];
+                490: components["responses"]["CustomResponse"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/responseBodyOpenapiTest": {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description custom header */
+                "custom-header"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /** @description custom header */
+                    "custom-header"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": number;
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                409: components["responses"]["Conflict"];
+                418: components["responses"]["CustomResponse"];
+                422: components["responses"]["ValidationErrors"];
+                490: components["responses"]["CustomResponse"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users": {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description custom header */
+                "custom-header"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /** @description custom header */
+                    "custom-header"?: string;
                 };
                 path?: never;
                 cookie?: never;
@@ -1069,9 +1630,9 @@ export interface paths {
         post: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path?: never;
                 cookie?: never;
@@ -1175,9 +1736,9 @@ export interface paths {
     "/users/{id}": {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path: {
                 /** @description The ID of the User */
@@ -1188,9 +1749,9 @@ export interface paths {
         get: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path: {
                     /** @description The ID of the User */
@@ -1225,9 +1786,9 @@ export interface paths {
         delete: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path: {
                     /** @description The ID of the User */
@@ -1260,9 +1821,9 @@ export interface paths {
         patch: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path: {
                     /** @description The ID of the User */
@@ -1358,9 +1919,9 @@ export interface paths {
     "/users/{id}/justforspecs": {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path: {
                 id: string;
@@ -1370,9 +1931,9 @@ export interface paths {
         get: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path: {
                     id: string;
@@ -1415,9 +1976,9 @@ export interface paths {
                 /** @description Page number */
                 page?: string;
             };
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path?: never;
             cookie?: never;
@@ -1428,9 +1989,9 @@ export interface paths {
                     /** @description Page number */
                     page?: string;
                 };
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path?: never;
                 cookie?: never;
@@ -1473,9 +2034,9 @@ export interface paths {
     "/users/paginated-post": {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description custom header */
-                "custom-header": string;
+                "custom-header"?: string;
             };
             path?: never;
             cookie?: never;
@@ -1485,9 +2046,9 @@ export interface paths {
         post: {
             parameters: {
                 query?: never;
-                header: {
+                header?: {
                     /** @description custom header */
-                    "custom-header": string;
+                    "custom-header"?: string;
                 };
                 path?: never;
                 cookie?: never;
@@ -1630,6 +2191,19 @@ export interface components {
             id: string;
             latexOnlySummaryAttr: string;
         };
+        OpenapiValidationErrors: {
+            /** @enum {string} */
+            type: "openapi";
+            /** @enum {string} */
+            target: "requestBody" | "query" | "headers" | "responseBody";
+            errors: {
+                instancePath: string;
+                schemaPath: string;
+                keyword: string;
+                message: string;
+                params: Record<string, never>;
+            }[];
+        };
         Pet: {
             id: string;
             name: string | null;
@@ -1670,7 +2244,9 @@ export interface components {
             posts: components["schemas"]["PostWithComments"][];
         };
         ValidationErrors: {
-            errors?: {
+            /** @enum {string} */
+            type: "validation";
+            errors: {
                 [key: string]: string[];
             };
         };
@@ -1687,13 +2263,13 @@ export interface components {
             };
             content?: never;
         };
-        /** @description The server would not process the request due to something the server considered to be a client error */
+        /** @description The server would not process the request due to something the server considered to be a client error, such as a model validation failure or an openapi validation failure */
         BadRequest: {
             headers: {
                 [name: string]: unknown;
             };
             content: {
-                "application/json": components["schemas"]["ValidationErrors"];
+                "application/json": components["schemas"]["ValidationErrors"] | components["schemas"]["OpenapiValidationErrors"];
             };
         };
         /** @description The request was not successful because it lacks valid authentication credentials for the requested resource */

--- a/yarn.lock
+++ b/yarn.lock
@@ -955,6 +955,8 @@ __metadata:
     "@types/pg": "npm:^8.11.8"
     "@types/supertest": "npm:^6.0.3"
     "@typescript/analyze-trace": "npm:^0.10.1"
+    ajv: "npm:^8.17.1"
+    ajv-formats: "npm:^3.0.1"
     commander: "npm:^12.1.0"
     cookie-parser: "npm:^1.4.7"
     cors: "npm:^2.8.5"
@@ -1585,6 +1587,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv-formats@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "ajv-formats@npm:3.0.1"
+  dependencies:
+    ajv: "npm:^8.0.0"
+  peerDependencies:
+    ajv: ^8.0.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: 10c0/168d6bca1ea9f163b41c8147bae537e67bd963357a5488a1eaf3abe8baa8eec806d4e45f15b10767e6020679315c7e1e5e6803088dfb84efa2b4e9353b83dd0a
+  languageName: node
+  linkType: hard
+
 "ajv@npm:^6.12.4":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
@@ -1594,6 +1610,18 @@ __metadata:
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
   checksum: 10c0/41e23642cbe545889245b9d2a45854ebba51cda6c778ebced9649420d9205f2efb39cb43dbc41e358409223b1ea43303ae4839db682c848b891e4811da1a5a71
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.0.0, ajv@npm:^8.17.1":
+  version: 8.17.1
+  resolution: "ajv@npm:8.17.1"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+  checksum: 10c0/ec3ba10a573c6b60f94639ffc53526275917a2df6810e4ab5a6b959d87459f9ef3f00d5e7865b82677cb7d21590355b34da14d1d0b9c32d75f95a187e76fff35
   languageName: node
   linkType: hard
 
@@ -3002,6 +3030,13 @@ __metadata:
   version: 2.1.1
   resolution: "fast-safe-stringify@npm:2.1.1"
   checksum: 10c0/d90ec1c963394919828872f21edaa3ad6f1dddd288d2bd4e977027afff09f5db40f94e39536d4646f7e01761d704d72d51dce5af1b93717f3489ef808f5f4e4d
+  languageName: node
+  linkType: hard
+
+"fast-uri@npm:^3.0.1":
+  version: 3.0.6
+  resolution: "fast-uri@npm:3.0.6"
+  checksum: 10c0/74a513c2af0584448aee71ce56005185f81239eab7a2343110e5bad50c39ad4fb19c5a6f99783ead1cac7ccaf3461a6034fda89fffa2b30b6d99b9f21c2f9d29
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
enables validation to be added to both openapi configurations, as well as to `OpenAPI` decorator calls, enabling the developer to granularly control validation logic for their endpoints.

To leverage global config:


```ts
// conf/app.ts
export default async (psy: PsychicApp) => {
  ...

  psy.set('openapi', {
    // ...
    validate: {
      headers: true,
      requestBody: true,
      query: true,
      responseBody: AppEnv.isTest,
    },
  })
}
```

To leverage endpoint config:

```ts
// controllers/PetsController
export default class PetsController {
  @OpenAPI(Pet, {
    ...
    validate: {
      headers: true,
      requestBody: true,
      query: true,
      responseBody: AppEnv.isTest,
    }
  })
  public async index() {
    ...
  }
}
```

This PR additionally formally introduces a new possible error type for 400 status codes, and to help distinguish, it also introduces a `type` field, which can be either `openapi` or `dream` to aid the developer in easily handling the various cases.

We have made a conscious decision to render openapi errors in the exact format that ajv returns, since it empowers the developer to utilize tools which can already respond to ajv errors.

For added flexibility, this PR includes the ability to provide configuration overrides for the ajv instance, as well as the ability to provide an initialization function to override ajv behavior, since much of the configuration for ajv is driven by method calls, rather than simple config.

```ts
// controllers/PetsController
export default class PetsController {
  @OpenAPI(Pet, {
    ...
    validate: {
      ajvOptions: {
        // this is off by default, but you will
        // always want to keep this off in prod
        // to avoid DoS vulnerabilities
        allErrors: AppEnv.isTest,

        // provide a custom init function to further
        // configure your ajv instance before validating
        init: ajv => {
          ajv.addFormat('myFormat', {
            type: 'string',
            validate: data => MY_FORMAT_REGEX.test(data),
          })
        }
      }
    }
  })
  public async index() {
    ...
  }
}
```

close https://rvohealth.atlassian.net/browse/PDTC-8387
