### PR TITLE
tighten validation to not coerce types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.1
+
+- do not coerce types in ajv when processing request or response bodies during validation. Type coercion will still happen for headers and query params, since they will need to respect the schema type specified in the openapi docuement.
+
 ## 1.8.0
 
 - remove unused `clientRoot` config

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/spec/unit/helpers/validateOpenapiSchema.spec.ts
+++ b/spec/unit/helpers/validateOpenapiSchema.spec.ts
@@ -16,16 +16,13 @@ describe('validateOpenApiSchema', () => {
     const validData = {
       id: '123e4567-e89b-12d3-a456-426614174000',
       name: 'John Doe',
-      age: '30', // use string to verify implicit coercion
+      age: 30,
       email: 'john@example.com',
     }
 
     const result = validateOpenApiSchema<typeof validData>(validData, openapiSchema)
     expect(result.isValid).toBe(true)
     expect(result.data!.age).toBe(30)
-
-    // ensure that original data is not mutated
-    expect(validData.age).toBe('30')
   })
 
   it('removes failing additional properties in OpenAPI mode without mutating original', () => {

--- a/spec/unit/scenarios/openapi/validation/responseBody.spec.ts
+++ b/spec/unit/scenarios/openapi/validation/responseBody.spec.ts
@@ -23,7 +23,7 @@ describe('openapi validation', () => {
               renderMe: '123',
             },
           })
-          expect(res.body).toEqual('123')
+          expect(res.body).toEqual(123)
         })
       })
 

--- a/src/helpers/validateOpenApiSchema.ts
+++ b/src/helpers/validateOpenApiSchema.ts
@@ -43,8 +43,6 @@ export default function validateOpenApiSchema<T = unknown>(
 ): ValidationResult<T> {
   return validateObject<T>(data, openapiSchema, {
     removeAdditional: 'failing', // Remove properties that fail validation
-    useDefaults: true,
-    coerceTypes: true,
     ...options,
   })
 }
@@ -118,9 +116,10 @@ export function createValidator<T = unknown>(
   const ajv = new Ajv({
     removeAdditional: false,
     useDefaults: true,
-    coerceTypes: true,
-    strict: false, // Allow unknown keywords for OpenAPI compatibility
-    allErrors: options.allErrors || false, // Collect all errors, not just the first one
+    strict: false,
+    coerceTypes: false,
+    strictTypes: true,
+    allErrors: false,
     validateFormats: true, // Enable format validation for date-time, email, etc.
     ...ajvOptions,
   })

--- a/src/server/params.ts
+++ b/src/server/params.ts
@@ -490,7 +490,7 @@ export default class Params {
 
       default:
         if (this.shouldUseOpenapiValidation(expectedType)) {
-          const res = validateObject(paramValue, expectedType)
+          const res = validateObject(paramValue, expectedType, { coerceTypes: true })
           if (res.isValid) {
             return res.data as ReturnType
           } else {

--- a/test-app/src/app/controllers/OpenapiValidationTestsController.ts
+++ b/test-app/src/app/controllers/OpenapiValidationTestsController.ts
@@ -134,7 +134,7 @@ export default class OpenapiValidationTestsController extends ApplicationControl
     },
   })
   public responseBodyOpenapiTest() {
-    this.ok(this.params.renderMe)
+    this.ok(this.params.renderMe && Number(this.params.renderMe))
   }
 
   @OpenAPI({
@@ -188,7 +188,7 @@ export default class OpenapiValidationTestsController extends ApplicationControl
   })
   public responseBodyObjectOpenapiTest() {
     this.ok({
-      requiredInt: this.params.requiredInt,
+      requiredInt: this.params.requiredInt && parseInt(this.params.requiredInt as string),
       optionalInt: this.params.optionalInt,
     })
   }


### PR DESCRIPTION
While coercing types seemed like the correct thing to do initially, realizing that ajv will coerce null to 0 for numeric types made this suddenly a very unappealing feature. The types we publish to json are already making allowances for i.e. bigints, etc, so we do not need to explicitly coerce here, unless we are validating schema for headers or query, since those will need to be coerced from strings to the correct schema types. We will also continue to lean into type coercion when leveraging castParam, since castParam already does coercion in many cases.

close https://rvohealth.atlassian.net/browse/PDTC-8476