### PR TITLE
don't raise exception when initializing psychic app with a missing route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.5
+
+Do not hard crash when initializing a psychic application when one of the openapi routes is not found for an openapi-decorated controller endpoint. We will continue to raise this exception when building openapi specs, but not when booting up the psychic application, since one can define routes that are i.e. not available in certain environments, and we don't want this to cause hard crashes when our app boots in those environments.
+
 ## 1.8.4
 
 - OpenAPI decorator with default 204 status does not throw an exception when passed a Dream model without a `serializers` getter

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/src/psychic-app/openapi-cache.ts
+++ b/src/psychic-app/openapi-cache.ts
@@ -40,7 +40,7 @@ export function getCachedOpenapiDocOrFail(openapiName: string) {
 export function cacheOpenapiDoc(openapiName: string, routes: RouteConfig[]): void {
   if (_openapiData[openapiName]) return
 
-  const openapiDoc = OpenapiAppRenderer._toObject(routes, openapiName)
+  const openapiDoc = OpenapiAppRenderer._toObject(routes, openapiName, { bypassMissingRoutes: true })
   _openapiData[openapiName] = openapiDoc?.components
     ? ({ components: openapiDoc.components } as OpenapiShell)
     : FILE_DOES_NOT_EXIST
@@ -57,6 +57,10 @@ export function cacheOpenapiDoc(openapiName: string, routes: RouteConfig[]): voi
  */
 export function ignoreOpenapiDoc(openapiName: string): void {
   _openapiData[openapiName] = FILE_WAS_IGNORED
+}
+
+export function _testOnlyClearOpenapiCache(openapiName: string) {
+  _openapiData[openapiName] = undefined as unknown as typeof FILE_WAS_IGNORED
 }
 
 const FILE_DOES_NOT_EXIST = 'FILE_DOES_NOT_EXIST'

--- a/test-app/src/app/controllers/OpenapiMissingRouteTestController.ts
+++ b/test-app/src/app/controllers/OpenapiMissingRouteTestController.ts
@@ -1,0 +1,17 @@
+import { OpenAPI } from '../../../../src/index.js'
+import ApplicationController from './ApplicationController.js'
+
+export default class OpenapiMissingRouteTestController extends ApplicationController {
+  @OpenAPI({
+    status: 204,
+    requestBody: {
+      type: 'object',
+      properties: {
+        numericParam: 'number',
+      },
+    },
+  })
+  public missingRoute() {
+    this.noContent()
+  }
+}

--- a/test-app/src/conf/routes.ts
+++ b/test-app/src/conf/routes.ts
@@ -20,6 +20,7 @@ import SerializerTestsController from '../app/controllers/SerializerTestsControl
 import UnauthedUsersController from '../app/controllers/UnauthedUsersController.js'
 import UsersController from '../app/controllers/UsersController.js'
 import User from '../app/models/User.js'
+import OpenapiMissingRouteTestController from '../app/controllers/OpenapiMissingRouteTestController.js'
 
 export default function routes(r: PsychicRouter) {
   r.get('circular', CircularController, 'hello')
@@ -273,4 +274,8 @@ export default function routes(r: PsychicRouter) {
     res.json({ id: (req.user as User)?.id })
   })
   r.get('controller-passport-test-persistence', PassportAuthedController, 'testPassportAuth')
+
+  if (process.env.SKIP_TEST_ROUTE !== '1') {
+    r.get('openapi-missing-route-test', OpenapiMissingRouteTestController, 'missingRoute')
+  }
 }

--- a/test-app/src/openapi/openapi.json
+++ b/test-app/src/openapi/openapi.json
@@ -1651,6 +1651,55 @@
         }
       }
     },
+    "/openapi-missing-route-test": {
+      "parameters": [
+        {
+          "in": "header",
+          "name": "custom-header",
+          "required": false,
+          "description": "custom header",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "responses": {
+          "204": {
+            "description": "Success, no content",
+            "$ref": "#/components/responses/NoContent"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "418": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationErrors"
+          },
+          "490": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
     "/openapi-validation-on-explicit-query-arrays": {
       "parameters": [
         {


### PR DESCRIPTION
this came up as an actual bug in some of our projects, since we will intentionally only allow some routes in our dev/stage environments. We will still raise an exception when building openapi docs, but not when initializing the app.

close https://rvohealth.atlassian.net/browse/PDTC-8521