### PR TITLE
Automatically rescue certain errors and convert them into status codes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.10.0
+
+- remove OpenAPI and Dream validation error response configuration and do not respond with errors (don't introduce such a difference between development and production environments)
+- log validation errors in test and dev (not prod to avoid DOS)
+- remove distinction between 400 and 422 to block ability of attacker to get feedback on how far into the system their request made it
+
 ## 1.9.0
 
 1. Validate params against OpenAPI at the latest possible of:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/spec/unit/openapi-renderer/app/buildOpenapiObject.spec.ts
+++ b/spec/unit/openapi-renderer/app/buildOpenapiObject.spec.ts
@@ -533,21 +533,7 @@ describe('OpenapiAppRenderer', () => {
 
               BadRequest: {
                 description:
-                  'The server would not process the request due to something the server considered to be a client error, such as a model validation failure or an openapi validation failure',
-                content: {
-                  'application/json': {
-                    schema: {
-                      oneOf: [
-                        {
-                          $ref: '#/components/schemas/ValidationErrors',
-                        },
-                        {
-                          $ref: '#/components/schemas/OpenapiValidationErrors',
-                        },
-                      ],
-                    },
-                  },
-                },
+                  'The server would not process the request due to something the server considered to be a client error',
               },
 
               // 401

--- a/spec/unit/scenarios/openapi/validation/headers.spec.ts
+++ b/spec/unit/scenarios/openapi/validation/headers.spec.ts
@@ -35,8 +35,6 @@ describe('openapi validation', () => {
 
       context('with invalid headers', () => {
         it('denies the request', async () => {
-          vi.spyOn(PsychicApp.prototype, 'includeDetailedOpenapiValidationErrors').mockReturnValue(true)
-
           const res = await request.get('/headersOpenapiTest', 400, {
             headers: {
               myDate: '2020-01-ABC',
@@ -44,54 +42,14 @@ describe('openapi validation', () => {
               myOptionalInt: '123.01',
             },
           })
-          expect(res.body).toEqual({
-            type: 'openapi',
-            target: 'headers',
-            errors: [
-              {
-                instancePath: '/myDate',
-                schemaPath: '#/properties/myDate/format',
-                keyword: 'format',
-                message: 'must match format "date"',
-                params: { format: 'date' },
-              },
-              {
-                instancePath: '/myOptionalDate',
-                schemaPath: '#/properties/myOptionalDate/format',
-                keyword: 'format',
-                message: 'must match format "date"',
-                params: { format: 'date' },
-              },
-              {
-                instancePath: '/myOptionalInt',
-                schemaPath: '#/properties/myOptionalInt/type',
-                keyword: 'type',
-                message: 'must be integer',
-                params: { type: 'integer' },
-              },
-            ],
-          })
+          expect(res.body).toEqual({})
         })
       })
 
       context('with missing required headers', () => {
         it('denies the request', async () => {
-          vi.spyOn(PsychicApp.prototype, 'includeDetailedOpenapiValidationErrors').mockReturnValue(true)
-
           const res = await request.get('/headersOpenapiTest', 400)
-          expect(res.body).toEqual({
-            type: 'openapi',
-            target: 'headers',
-            errors: [
-              {
-                instancePath: '',
-                schemaPath: '#/required',
-                keyword: 'required',
-                message: "must have required property 'myDate'",
-                params: { missingProperty: 'myDate' },
-              },
-            ],
-          })
+          expect(res.body).toEqual({})
         })
       })
 

--- a/spec/unit/scenarios/openapi/validation/query.spec.ts
+++ b/spec/unit/scenarios/openapi/validation/query.spec.ts
@@ -39,47 +39,19 @@ describe('openapi validation', () => {
 
       context('with an invalid query', () => {
         it('rejects the request', async () => {
-          vi.spyOn(PsychicApp.prototype, 'includeDetailedOpenapiValidationErrors').mockReturnValue(true)
-
           const res = await request.get('/queryOpenapiTest', 400, {
             query: {
               numericParam: ['hello'],
             },
           })
-          expect(res.body).toEqual({
-            type: 'openapi',
-            target: 'query',
-            errors: [
-              {
-                instancePath: '/numericParam',
-                schemaPath: '#/properties/numericParam/type',
-                keyword: 'type',
-                message: 'must be number',
-                params: { type: 'number' },
-              },
-            ],
-          })
+          expect(res.body).toEqual({})
         })
       })
 
       context('with missing required query params', () => {
         it('denies the request', async () => {
-          vi.spyOn(PsychicApp.prototype, 'includeDetailedOpenapiValidationErrors').mockReturnValue(true)
-
           const res = await request.get('/queryRequiredOpenapiTest', 400)
-          expect(res.body).toEqual({
-            type: 'openapi',
-            target: 'query',
-            errors: [
-              {
-                instancePath: '',
-                schemaPath: '#/required',
-                keyword: 'required',
-                message: "must have required property 'requiredStringParam'",
-                params: { missingProperty: 'requiredStringParam' },
-              },
-            ],
-          })
+          expect(res.body).toEqual({})
         })
       })
 

--- a/spec/unit/scenarios/openapi/validation/requestBody.spec.ts
+++ b/spec/unit/scenarios/openapi/validation/requestBody.spec.ts
@@ -46,71 +46,8 @@ describe('openapi validation', () => {
         })
       })
 
-      context('detailedErrors: true', () => {
-        beforeEach(() => {
-          vi.spyOn(
-            OpenapiEndpointRenderer.prototype,
-            'includeDetailedOpenapiValidationErrors',
-          ).mockReturnValue(true)
-        })
-
-        context('with an invalid requestBody', () => {
-          it('denies the request with errors', async () => {
-            const user = await User.create({ email: 'how@yadoin', password: 'howyadoin' })
-            const res = await request.post('/pets', 400, {
-              data: {
-                name: ['abc'],
-                species: 'cat',
-                nonNullSpecies: 'cat',
-                nonNullFavoriteTreats: [],
-                userId: user.id,
-              },
-            })
-            expect(res.body).toEqual({
-              type: 'openapi',
-              target: 'requestBody',
-              errors: [
-                {
-                  instancePath: '/name',
-                  schemaPath: '#/properties/name/type',
-                  keyword: 'type',
-                  message: 'must be string,null',
-                  params: { type: ['string', 'null'] },
-                },
-              ],
-            })
-          })
-        })
-
-        context('with missing required fields', () => {
-          it('denies the request with errors', async () => {
-            const res = await request.post('/requestBodyOpenapiTest', 400)
-            expect(res.body).toEqual({
-              type: 'openapi',
-              target: 'requestBody',
-              errors: [
-                {
-                  instancePath: '',
-                  schemaPath: '#/required',
-                  keyword: 'required',
-                  message: "must have required property 'requiredInt'",
-                  params: { missingProperty: 'requiredInt' },
-                },
-              ],
-            })
-          })
-        })
-      })
-
-      context('detailedErrors: false', () => {
-        beforeEach(() => {
-          vi.spyOn(
-            OpenapiEndpointRenderer.prototype,
-            'includeDetailedOpenapiValidationErrors',
-          ).mockReturnValue(false)
-        })
-
-        it('invalid requests do not include error messages', async () => {
+      context('with an invalid requestBody', () => {
+        it('denies the request', async () => {
           const user = await User.create({ email: 'how@yadoin', password: 'howyadoin' })
           const res = await request.post('/pets', 400, {
             data: {
@@ -125,18 +62,9 @@ describe('openapi validation', () => {
         })
       })
 
-      context('detailedErrors is not set', () => {
-        it('invalid requests do not include error messages', async () => {
-          const user = await User.create({ email: 'how@yadoin', password: 'howyadoin' })
-          const res = await request.post('/pets', 400, {
-            data: {
-              name: ['abc'],
-              species: 'cat',
-              nonNullSpecies: 'cat',
-              nonNullFavoriteTreats: [],
-              userId: user.id,
-            },
-          })
+      context('with missing required fields', () => {
+        it('denies the request', async () => {
+          const res = await request.post('/requestBodyOpenapiTest', 400)
           expect(res.body).toEqual({})
         })
       })
@@ -208,74 +136,6 @@ describe('openapi validation', () => {
                 userId: user.id,
               },
             })
-          })
-        })
-
-        context('detailedErrors: true', () => {
-          beforeEach(() => {
-            vi.spyOn(PsychicApp.prototype, 'includeDetailedOpenapiValidationErrors').mockReturnValue(true)
-          })
-
-          it('invalid requests include error messages', async () => {
-            const user = await User.create({ email: 'how@yadoin', password: 'howyadoin' })
-            const res = await request.post('/pets', 400, {
-              data: {
-                name: ['abc'],
-                species: 'cat',
-                nonNullSpecies: 'cat',
-                nonNullFavoriteTreats: [],
-                userId: user.id,
-              },
-            })
-            expect(res.body).toEqual({
-              type: 'openapi',
-              target: 'requestBody',
-              errors: [
-                {
-                  instancePath: '/name',
-                  schemaPath: '#/properties/name/type',
-                  keyword: 'type',
-                  message: 'must be string,null',
-                  params: { type: ['string', 'null'] },
-                },
-              ],
-            })
-          })
-        })
-
-        context('detailedErrors: false', () => {
-          beforeEach(() => {
-            vi.spyOn(PsychicApp.prototype, 'includeDetailedOpenapiValidationErrors').mockReturnValue(false)
-          })
-
-          it('invalid requests do not include error messages', async () => {
-            const user = await User.create({ email: 'how@yadoin', password: 'howyadoin' })
-            const res = await request.post('/pets', 400, {
-              data: {
-                name: ['abc'],
-                species: 'cat',
-                nonNullSpecies: 'cat',
-                nonNullFavoriteTreats: [],
-                userId: user.id,
-              },
-            })
-            expect(res.body).toEqual({})
-          })
-        })
-
-        context('detailedErrors is not set', () => {
-          it('invalid requests do not include error messages', async () => {
-            const user = await User.create({ email: 'how@yadoin', password: 'howyadoin' })
-            const res = await request.post('/pets', 400, {
-              data: {
-                name: ['abc'],
-                species: 'cat',
-                nonNullSpecies: 'cat',
-                nonNullFavoriteTreats: [],
-                userId: user.id,
-              },
-            })
-            expect(res.body).toEqual({})
           })
         })
 

--- a/spec/unit/scenarios/saving-records.spec.ts
+++ b/spec/unit/scenarios/saving-records.spec.ts
@@ -1,7 +1,7 @@
 import { specRequest as request } from '@rvoh/psychic-spec-helpers'
+import { PsychicApp } from '../../../src/index.js'
 import PsychicServer from '../../../src/server/index.js'
 import User from '../../../test-app/src/app/models/User.js'
-import { PsychicApp } from '../../../src/index.js'
 
 describe('a visitor attempts to save a record', () => {
   beforeEach(async () => {
@@ -22,9 +22,9 @@ describe('a visitor attempts to save a record', () => {
   })
 
   context('with a record that is invalid at Dream validation level', () => {
-    it('does not save, returns 422', async () => {
-      const res = await request.post('/failed-to-save-test', 422)
-      expect(res.body).toEqual({ type: 'validator', errors: { email: ['contains'] } })
+    it('does not save, returns 400', async () => {
+      const res = await request.post('/failed-to-save-test', 400)
+      expect(res.body).toEqual({})
     })
   })
 
@@ -56,10 +56,7 @@ describe('a visitor attempts to save a record', () => {
         const response = await request.post('/users', 400, {
           data: { user: { email: 123, password: 'howyadoin', name: 456 } },
         })
-        expect(response.body).toEqual({
-          type: 'validator',
-          errors: { email: ['expected string'], name: ['expected string'] },
-        })
+        expect(response.body).toEqual({})
         expect(await User.count()).toEqual(0)
       })
     },

--- a/src/error/openapi/OpenapiValidationFailure.ts
+++ b/src/error/openapi/OpenapiValidationFailure.ts
@@ -4,7 +4,6 @@ export default class OpenapiValidationFailure extends Error {
   constructor(
     public errors: OpenapiValidationError[],
     public target: OpenapiValidateTarget,
-    public includeDetailedOpenapiValidationErrors: boolean,
   ) {
     super()
   }

--- a/src/openapi-renderer/defaults.ts
+++ b/src/openapi-renderer/defaults.ts
@@ -86,21 +86,7 @@ export const DEFAULT_OPENAPI_COMPONENT_RESPONSES = {
   // 400
   BadRequest: {
     description:
-      'The server would not process the request due to something the server considered to be a client error, such as a model validation failure or an openapi validation failure',
-    content: {
-      'application/json': {
-        schema: {
-          oneOf: [
-            {
-              $ref: '#/components/schemas/ValidationErrors',
-            },
-            {
-              $ref: '#/components/schemas/OpenapiValidationErrors',
-            },
-          ],
-        },
-      },
-    },
+      'The server would not process the request due to something the server considered to be a client error',
   },
 
   // 401

--- a/src/openapi-renderer/endpoint.ts
+++ b/src/openapi-renderer/endpoint.ts
@@ -161,19 +161,6 @@ export default class OpenapiEndpointRenderer<
     this.defaultResponse = defaultResponse
     this.validate = validate
   }
-  /**
-   * @internal
-   *
-   * reads the validation options for this particular endpoint. If they
-   * explicitly permit or don't permit detailed validation errors, then it
-   * will return true or false. If detailed validation errors are not set on this endpoint,
-   * it will fall back to PsychicApp to see if detailed validation errors are turned on
-   * globally for the given openapiName.
-   */
-  public includeDetailedOpenapiValidationErrors(openapiName: string) {
-    if (this.validate?.detailedErrors !== undefined) return this.validate.detailedErrors
-    return PsychicApp.getOrFail().includeDetailedOpenapiValidationErrors(openapiName)
-  }
 
   /**
    * @internal
@@ -1385,12 +1372,6 @@ export interface OpenapiEndpointRendererOpts<
 }
 
 export type OpenapiValidateOption = {
-  /**
-   * set to true to include detailed errors when openapi validation fails
-   * (false or undefined result in only a 400 status code with no details)
-   */
-  detailedErrors?: boolean
-
   /**
    * set to true to validate the request body against the openapi schema
    */

--- a/src/openapi-renderer/helpers/OpenapiPayloadValidator.ts
+++ b/src/openapi-renderer/helpers/OpenapiPayloadValidator.ts
@@ -305,11 +305,7 @@ export default class OpenapiPayloadValidator {
     if (!validationResults.isValid) {
       const errorClass =
         target === 'responseBody' ? OpenapiResponseValidationFailure : OpenapiRequestValidationFailure
-      throw new errorClass(
-        validationResults.errors || [],
-        target,
-        this.openapiEndpointRenderer.includeDetailedOpenapiValidationErrors(this.openapiName),
-      )
+      throw new errorClass(validationResults.errors || [], target)
     }
   }
 

--- a/src/psychic-app/index.ts
+++ b/src/psychic-app/index.ts
@@ -408,17 +408,6 @@ Try setting it to something valid, like:
    * @internal
    *
    * @param openapiName - the openapiName you are looking to check validation for
-   * @returns true if configured to return detailed OpenAPI validation errors
-   */
-  public includeDetailedOpenapiValidationErrors(openapiName: string): boolean {
-    const openapiConf = this.openapi[openapiName]
-    return openapiConf?.validate?.detailedErrors || false
-  }
-
-  /**
-   * @internal
-   *
-   * @param openapiName - the openapiName you are looking to check validation for
    * @param target - the target for the validation, either 'requestBody', 'headers', 'query', or 'responseBody'
    * @returns true if the validation for this particular openapiName is active
    */

--- a/test-app/src/openapi/admin.openapi.json
+++ b/test-app/src/openapi/admin.openapi.json
@@ -215,21 +215,7 @@
         "description": "The request has succeeded, but there is no content to render"
       },
       "BadRequest": {
-        "description": "The server would not process the request due to something the server considered to be a client error, such as a model validation failure or an openapi validation failure",
-        "content": {
-          "application/json": {
-            "schema": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/ValidationErrors"
-                },
-                {
-                  "$ref": "#/components/schemas/OpenapiValidationErrors"
-                }
-              ]
-            }
-          }
-        }
+        "description": "The server would not process the request due to something the server considered to be a client error"
       },
       "Unauthorized": {
         "description": "The request was not successful because it lacks valid authentication credentials for the requested resource"

--- a/test-app/src/openapi/mobile.openapi.json
+++ b/test-app/src/openapi/mobile.openapi.json
@@ -232,21 +232,7 @@
         "description": "The request has succeeded, but there is no content to render"
       },
       "BadRequest": {
-        "description": "The server would not process the request due to something the server considered to be a client error, such as a model validation failure or an openapi validation failure",
-        "content": {
-          "application/json": {
-            "schema": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/ValidationErrors"
-                },
-                {
-                  "$ref": "#/components/schemas/OpenapiValidationErrors"
-                }
-              ]
-            }
-          }
-        }
+        "description": "The server would not process the request due to something the server considered to be a client error"
       },
       "Unauthorized": {
         "description": "The request was not successful because it lacks valid authentication credentials for the requested resource"

--- a/test-app/src/openapi/openapi.json
+++ b/test-app/src/openapi/openapi.json
@@ -5115,21 +5115,7 @@
         "description": "The request has succeeded, but there is no content to render"
       },
       "BadRequest": {
-        "description": "The server would not process the request due to something the server considered to be a client error, such as a model validation failure or an openapi validation failure",
-        "content": {
-          "application/json": {
-            "schema": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/ValidationErrors"
-                },
-                {
-                  "$ref": "#/components/schemas/OpenapiValidationErrors"
-                }
-              ]
-            }
-          }
-        }
+        "description": "The server would not process the request due to something the server considered to be a client error"
       },
       "Unauthorized": {
         "description": "The request was not successful because it lacks valid authentication credentials for the requested resource"

--- a/test-app/src/types/openapi/openapi.d.ts
+++ b/test-app/src/types/openapi/openapi.d.ts
@@ -530,6 +530,114 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/beforeAction403": {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description custom header */
+                "custom-header"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /** @description custom header */
+                    "custom-header"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        stringParam?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                400: components["responses"]["BadRequest"];
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                409: components["responses"]["Conflict"];
+                418: components["responses"]["CustomResponse"];
+                422: components["responses"]["ValidationErrors"];
+                490: components["responses"]["CustomResponse"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/beforeActionParamsAccessed": {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description custom header */
+                "custom-header"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /** @description custom header */
+                    "custom-header"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        stringParam?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                400: components["responses"]["BadRequest"];
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                409: components["responses"]["Conflict"];
+                418: components["responses"]["CustomResponse"];
+                422: components["responses"]["ValidationErrors"];
+                490: components["responses"]["CustomResponse"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/circular": {
         parameters: {
             query?: never;
@@ -849,6 +957,49 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/openapi-missing-route-test": {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description custom header */
+                "custom-header"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /** @description custom header */
+                    "custom-header"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Success, no content */
+                204: components["responses"]["NoContent"];
+                400: components["responses"]["BadRequest"];
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                409: components["responses"]["Conflict"];
+                418: components["responses"]["CustomResponse"];
+                422: components["responses"]["ValidationErrors"];
+                490: components["responses"]["CustomResponse"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/openapi-validation-on-explicit-query-arrays": {
         parameters: {
             query?: {
@@ -877,8 +1028,8 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description Success */
-                200: {
+                /** @description Success, no content */
+                204: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -931,8 +1082,8 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description Success */
-                200: {
+                /** @description Success, no content */
+                204: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -987,8 +1138,8 @@ export interface paths {
                 };
             };
             responses: {
-                /** @description Success */
-                200: {
+                /** @description Success, no content */
+                204: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -2268,8 +2419,8 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description Success */
-                200: {
+                /** @description Success, no content */
+                204: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -2801,14 +2952,12 @@ export interface components {
             };
             content?: never;
         };
-        /** @description The server would not process the request due to something the server considered to be a client error, such as a model validation failure or an openapi validation failure */
+        /** @description The server would not process the request due to something the server considered to be a client error */
         BadRequest: {
             headers: {
                 [name: string]: unknown;
             };
-            content: {
-                "application/json": components["schemas"]["ValidationErrors"] | components["schemas"]["OpenapiValidationErrors"];
-            };
+            content?: never;
         };
         /** @description The request was not successful because it lacks valid authentication credentials for the requested resource */
         Unauthorized: {


### PR DESCRIPTION
Validation errors (OpenAPI or otherwise) are by default converted to
400. 422 MUST ONLY be returned when accompanied by a ValidationErrors payload (even if the errors object is empty) that is intended to be displayed to the end user to indicate fields that must be corrected to be accepted.

Philosophy: do not return information (even difference between 400 & 422) unless it is explicitly intended for that information to be used to enable a front end interface to display information to support user-visible validation (e.g. an email must be formatted correctly).

By default, do not provide an attacker with any visibility into which layer of the application rejected their request.

Addresses https://rvohealth.atlassian.net/browse/PDTC-8530
Addresses https://rvohealth.atlassian.net/browse/PDTC-8531