### PR TITLE
OpenAPI and castParam validation errors are logged only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.10.0
 
+- OpenAPI and castParam validation errors are logged only when `NODE_DEBUG=psychic`
+
+## 1.10.0
+
 - remove OpenAPI and Dream validation error response configuration and do not respond with errors (don't introduce such a difference between development and production environments)
 - log validation errors in test and dev (not prod to avoid DOS)
 - remove distinction between 400 and 422 to block ability of attacker to get feedback on how far into the system their request made it

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -7,7 +7,7 @@ import {
   ValidationError,
 } from '@rvoh/dream'
 import { Application, Request, RequestHandler, Response, Router } from 'express'
-import util from 'node:util'
+import util, { debuglog } from 'node:util'
 import pluralize from 'pluralize-esm'
 import PsychicController from '../controller/index.js'
 import ParamValidationError from '../error/controller/ParamValidationError.js'
@@ -378,7 +378,7 @@ suggested fix:  "${convertRouteParams(path)}"
   }
 
   private get validationErrorLoggingEnabled(): boolean {
-    return EnvInternal.isDevelopment
+    return debuglog('psychic').enabled
   }
 
   /**


### PR DESCRIPTION
when `NODE_DEBUG=psychic`