### PR TITLE
prioritize server error hooks, cleanup bad logging habits

### DIFF
--- a/spec/unit/scenarios/server-error-hooks.spec.ts
+++ b/spec/unit/scenarios/server-error-hooks.spec.ts
@@ -1,0 +1,73 @@
+import { specRequest as request } from '@rvoh/psychic-spec-helpers'
+import { PsychicServer } from '../../../src/index.js'
+
+describe('server error hooks', () => {
+  beforeEach(async () => {
+    process.env.FORCE_THROW_DURING_SERVER_ERROR = '1'
+    await request.init(PsychicServer)
+  })
+
+  afterEach(() => {
+    process.env.FORCE_THROW_DURING_SERVER_ERROR = undefined
+  })
+
+  context('status codes to handle', () => {
+    context('random error', () => {
+      it('calls user-defined serverError hooks', async () => {
+        await request.get('/server-errors/unexpected-error', 418)
+      })
+
+      context('when the serverError handler throws the original error', () => {
+        it('continues to process the error as usual', async () => {
+          process.env.FORCE_THROW_DURING_SERVER_ERROR = undefined
+          await request.get('/server-errors/unexpected-error', 500)
+        })
+      })
+    })
+
+    context('openapi failure (400)', () => {
+      it('calls user-defined serverError hooks', async () => {
+        await request.get('/server-errors/openapi-error', 418)
+      })
+
+      context('when the serverError handler throws the original error', () => {
+        it('continues to process the error as usual', async () => {
+          process.env.FORCE_THROW_DURING_SERVER_ERROR = undefined
+          await request.get('/server-errors/openapi-error', 400)
+        })
+      })
+    })
+  })
+
+  context('ignorable status codes', () => {
+    context('400', () => {
+      it('does not call serverError hooks', async () => {
+        await request.get('/server-errors/bad-request', 400)
+      })
+    })
+
+    context('401', () => {
+      it('does not call serverError hooks', async () => {
+        await request.get('/server-errors/unauthorized-error', 401)
+      })
+    })
+
+    context('403', () => {
+      it('does not call serverError hooks', async () => {
+        await request.get('/server-errors/forbidden-error', 403)
+      })
+    })
+
+    context('404', () => {
+      it('does not call serverError hooks', async () => {
+        await request.get('/server-errors/not-found-error', 404)
+      })
+    })
+
+    context('RecordNotFound (404)', () => {
+      it('does not call serverError hooks', async () => {
+        await request.get('/server-errors/record-not-found-error', 404)
+      })
+    })
+  })
+})

--- a/test-app/src/app/controllers/ServerErrorTestsController.ts
+++ b/test-app/src/app/controllers/ServerErrorTestsController.ts
@@ -1,0 +1,50 @@
+import { OpenAPI } from '../../../../src/index.js'
+import User from '../models/User.js'
+import ApplicationController from './ApplicationController.js'
+
+export default class ServerErrorTestsController extends ApplicationController {
+  public testServerErrorHandlerWithUnexpectedError() {
+    // this will throw a 403, which should cause the
+    // underlying error handlers to pick it up,
+    throw new Error('testing handlers for unknown errors')
+  }
+
+  public testServerErrorHandlerWithBadRequest() {
+    // 400 should be picked up by custom error handler
+    this.badRequest()
+  }
+
+  @OpenAPI({
+    query: {
+      // tests will intentionally leave this field blank
+      // to trigger an openapi validation failure
+      howyadoin: {
+        required: true,
+      },
+    },
+  })
+  public testServerErrorHandlerWithOpenapiFailure() {
+    this.noContent()
+  }
+
+  public testServerErrorHandlerWithForbidden() {
+    // 403 should not be picked up by custom error handler
+    this.forbidden()
+  }
+
+  public testServerErrorHandlerWithUnauthorized() {
+    // 401 should not be picked up by custom error handler
+    this.unauthorized()
+  }
+
+  public testServerErrorHandlerWithNotFound() {
+    // 404 should not be picked up by custom error handler
+    this.notFound()
+  }
+
+  public async testServerErrorHandlerWithRecordNotFound() {
+    // not finding records within dream should raise a 404,
+    // and not be picked up by custom error handler
+    await User.findOrFail('1234566789')
+  }
+}

--- a/test-app/src/conf/app.ts
+++ b/test-app/src/conf/app.ts
@@ -6,7 +6,6 @@ import { debuglog } from 'node:util'
 import passport from 'passport'
 import { Strategy as LocalStrategy } from 'passport-local'
 import * as winston from 'winston'
-import EnvInternal from '../../../src/helpers/EnvInternal.js'
 import { PsychicDevtools } from '../../../src/index.js'
 import PsychicApp from '../../../src/psychic-app/index.js'
 import importDefault from '../app/helpers/importDefault.js'
@@ -253,8 +252,12 @@ export default async (psy: PsychicApp) => {
       console.error(err)
     }
 
-    if (!res.headersSent) res.sendStatus(500)
-    else if (EnvInternal.isDevelopmentOrTest) throw err
+    if (process.env.FORCE_THROW_DURING_SERVER_ERROR === '1') {
+      res.sendStatus(418)
+    }
+
+    // if (!res.headersSent) res.sendStatus(500)
+    else throw err
   })
 
   psy.on('server:start', async () => {
@@ -323,6 +326,8 @@ export default async (psy: PsychicApp) => {
   )
   // end: passport test setup
 }
+
+export class IntentionalServerErrorToTestHookExecution extends Error {}
 
 export function __forTestingOnly(message: string) {
   process.env.__PSYCHIC_HOOKS_TEST_CACHE ||= ''

--- a/test-app/src/conf/routes.ts
+++ b/test-app/src/conf/routes.ts
@@ -21,6 +21,7 @@ import SerializerTestsController from '../app/controllers/SerializerTestsControl
 import UnauthedUsersController from '../app/controllers/UnauthedUsersController.js'
 import UsersController from '../app/controllers/UsersController.js'
 import User from '../app/models/User.js'
+import ServerErrorTestsController from '../app/controllers/ServerErrorTestsController.js'
 
 export default function routes(r: PsychicRouter) {
   r.get('circular', CircularController, 'hello')
@@ -54,6 +55,25 @@ export default function routes(r: PsychicRouter) {
   r.get('openapi/request-body-for-type', OpenapiDecoratorTestController, 'testRequestBodyForType')
   r.get('openapi/multiple-serializer-statements', OpenapiDecoratorTestController, 'testMultipleSerializers')
   r.get('openapi/openapi-overrides', OpenapiOverridesTestController, 'testOpenapiConfigOverrides')
+  r.get(
+    'server-errors/unexpected-error',
+    ServerErrorTestsController,
+    'testServerErrorHandlerWithUnexpectedError',
+  )
+  r.get('server-errors/bad-request', ServerErrorTestsController, 'testServerErrorHandlerWithBadRequest')
+  r.get('server-errors/openapi-error', ServerErrorTestsController, 'testServerErrorHandlerWithOpenapiFailure')
+  r.get('server-errors/forbidden-error', ServerErrorTestsController, 'testServerErrorHandlerWithForbidden')
+  r.get(
+    'server-errors/unauthorized-error',
+    ServerErrorTestsController,
+    'testServerErrorHandlerWithUnauthorized',
+  )
+  r.get('server-errors/not-found-error', ServerErrorTestsController, 'testServerErrorHandlerWithNotFound')
+  r.get(
+    'server-errors/record-not-found-error',
+    ServerErrorTestsController,
+    'testServerErrorHandlerWithRecordNotFound',
+  )
 
   r.resources('users', r => {
     r.collection(r => {

--- a/test-app/src/openapi/openapi.json
+++ b/test-app/src/openapi/openapi.json
@@ -3412,6 +3412,64 @@
         }
       }
     },
+    "/server-errors/openapi-error": {
+      "parameters": [
+        {
+          "in": "header",
+          "name": "custom-header",
+          "required": false,
+          "description": "custom header",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "in": "query",
+          "name": "howyadoin",
+          "description": "howyadoin",
+          "allowReserved": true,
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "responses": {
+          "204": {
+            "description": "Success, no content"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "418": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationErrors"
+          },
+          "490": {
+            "$ref": "#/components/responses/CustomResponse"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
     "/users": {
       "parameters": [
         {


### PR DESCRIPTION
Before merging, we should have a discussion about which errors should be rescuable. IMHO, and as is currently implemented, we should only rescue:

* openapi validation errors
* dream validation errors
* misc errors that are not known to psychic

drafting until we have a formal discussion