### PR TITLE
Turn all database level validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 1.10.0
+## 1.10.2
+
+- return 400 instead of throwing error and 500 when there is a column overflow at the database level (let database validation suffice for enforcing data length validation rather than requiring model level validation)
+
+## 1.10.1
 
 - OpenAPI and castParam validation errors are logged only when `NODE_DEBUG=psychic`
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "author": "RVOHealth",
   "repository": {
     "type": "git",
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@eslint/js": "^9.19.0",
     "@jest-mock/express": "^3.0.0",
-    "@rvoh/dream": "^1.7.0",
+    "@rvoh/dream": "^1.8.0",
     "@rvoh/dream-spec-helpers": "^1.1.1",
     "@rvoh/psychic-spec-helpers": "^1.0.0",
     "@types/express": "^5.0.1",

--- a/spec/unit/scenarios/saving-records.spec.ts
+++ b/spec/unit/scenarios/saving-records.spec.ts
@@ -29,8 +29,14 @@ describe('a visitor attempts to save a record', () => {
   })
 
   context('saving data that is incompatible with the column type', () => {
-    it('does not save, returns 400', async () => {
+    it('returns 400', async () => {
       await request.post('/fail-saving-incompatible-data-test', 400)
+    })
+  })
+
+  context('saving data that is too long for a column', () => {
+    it('returns 400', async () => {
+      await request.post('/fail-saving-too-long-data', 400)
     })
   })
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,11 +1,4 @@
-import {
-  camelize,
-  CheckConstraintViolation,
-  DataTypeColumnTypeMismatch,
-  NotNullViolation,
-  RecordNotFound,
-  ValidationError,
-} from '@rvoh/dream'
+import { camelize, DataIncompatibleWithDatabaseField, RecordNotFound, ValidationError } from '@rvoh/dream'
 import { Application, Request, RequestHandler, Response, Router } from 'express'
 import util, { debuglog } from 'node:util'
 import pluralize from 'pluralize-esm'
@@ -429,12 +422,7 @@ suggested fix:  "${convertRouteParams(path)}"
         }
       } else if (err instanceof RecordNotFound) {
         res.sendStatus(404)
-      } else if (err instanceof NotNullViolation || err instanceof CheckConstraintViolation) {
-        /**
-         * See comment at top of this method for philosophy of 400
-         */
-        res.sendStatus(400)
-      } else if (err instanceof DataTypeColumnTypeMismatch) {
+      } else if (err instanceof DataIncompatibleWithDatabaseField) {
         /**
          * See comment at top of this method for philosophy of 400
          */

--- a/test-app/src/app/controllers/UsersController.ts
+++ b/test-app/src/app/controllers/UsersController.ts
@@ -45,6 +45,14 @@ export default class UsersController extends ApplicationController {
     })
   }
 
+  public async failSavingTooLongData() {
+    await User.create({
+      email: 'how@yadoin',
+      password: 'howyadoin',
+      volume: 99999999,
+    })
+  }
+
   public forceThrow() {
     throw new Error('this should force a 500')
   }

--- a/test-app/src/conf/routes.ts
+++ b/test-app/src/conf/routes.ts
@@ -146,6 +146,7 @@ export default function routes(r: PsychicRouter) {
   r.get('users-before-action-sequence', UsersController, 'beforeActionSequence')
   r.post('failed-to-save-test', UsersController, 'failedToSaveTest')
   r.post('fail-saving-incompatible-data-test', UsersController, 'failSavingIncompatibleDataTest')
+  r.post('fail-saving-too-long-data', UsersController, 'failSavingTooLongData')
   r.post('force-throw', UsersController, 'forceThrow')
 
   // response status tests

--- a/yarn.lock
+++ b/yarn.lock
@@ -900,9 +900,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rvoh/dream@npm:^1.7.0":
-  version: 1.7.0
-  resolution: "@rvoh/dream@npm:1.7.0"
+"@rvoh/dream@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "@rvoh/dream@npm:1.8.0"
   dependencies:
     colorette: "npm:^2.0.20"
     commander: "npm:^12.1.0"
@@ -917,7 +917,7 @@ __metadata:
     kysely: ^0.27.4
     kysely-codegen: ~0.17.0
     pg: "*"
-  checksum: 10c0/1f98e4e0bee3de4bcbdcb01650829bcc5a7fe5b18bd190ed3f850469c62252c0c279ed90f226b4202743e53cfe8e7b9cdce58200ed0187219731a74bc557143b
+  checksum: 10c0/42a5aa8eff46d0334e4cfc52e04522e4b08b8c3bb7894f5215d087c4d4d7ce58aa76da588f46548f938de4649342399f2bcbd7c39e5675ed46d020b5d335c1c7
   languageName: node
   linkType: hard
 
@@ -942,7 +942,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.19.0"
     "@jest-mock/express": "npm:^3.0.0"
-    "@rvoh/dream": "npm:^1.7.0"
+    "@rvoh/dream": "npm:^1.8.0"
     "@rvoh/dream-spec-helpers": "npm:^1.1.1"
     "@rvoh/psychic-spec-helpers": "npm:^1.0.0"
     "@types/cookie-parser": "npm:^1.4.8"


### PR DESCRIPTION
into 400 status errors rather than 500

Handle this generally so that Dream can
add more exceptions in the future without
requiring Psychic to change

https://rvohealth.atlassian.net/browse/PDTC-5249