### PR TITLE
fix issue causing enum descriptions to render with wrong values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.4
+
+Fix issue with rendering incorrect enum descriptions when suppressResponseEnums is set to true and enums are explicitly overridden in the openapi option.
+
 ## 1.10.3
 
 - respect `required: false` when generating OpenAPI spec

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/spec/unit/openapi-renderer/endpoint/toSchemaObject.spec.ts
+++ b/spec/unit/openapi-renderer/endpoint/toSchemaObject.spec.ts
@@ -32,6 +32,10 @@ import {
   CommentWithOneOfArraySerializer,
   CommentWithOneOfObjectSerializer,
 } from '../../../../test-app/src/app/serializers/CommentSerializer.js'
+import {
+  PetWithFavoriteTreatsOverrideSerializer,
+  PetWithFavoriteTreatsSerializer,
+} from '../../../../test-app/src/app/serializers/PetSerializer.js'
 import MyViewModel from '../../../../test-app/src/app/view-models/MyViewModel.js'
 
 describe('OpenapiEndpointRenderer', () => {
@@ -296,40 +300,127 @@ describe('OpenapiEndpointRenderer', () => {
       })
 
       context('suppressResponseEnums=true', () => {
-        it('suppresses enums, instead using description to clarify enum options', () => {
-          const renderer = new OpenapiEndpointRenderer(
-            CommentTestingStringSerializer,
-            UsersController,
-            'howyadoin',
-            {},
-          )
+        context('with an object serializer', () => {
+          it('suppresses enums, instead using description to clarify enum options', () => {
+            const renderer = new OpenapiEndpointRenderer(
+              CommentTestingStringSerializer,
+              UsersController,
+              'howyadoin',
+              {},
+            )
 
-          const toSchemaObjectOpts = defaultToSchemaObjectOpts({
-            renderOpts: { casing: 'camel', suppressResponseEnums: true },
-          })
-          renderer.toSchemaObject(toSchemaObjectOpts)
+            const toSchemaObjectOpts = defaultToSchemaObjectOpts({
+              renderOpts: { casing: 'camel', suppressResponseEnums: true },
+            })
+            renderer.toSchemaObject(toSchemaObjectOpts)
 
-          expect(toSchemaObjectOpts.renderedSchemasOpenapi).toEqual(
-            expect.objectContaining({
-              CommentTestingString: {
-                type: 'object',
-                required: ['howyadoin'],
-                properties: {
-                  howyadoin: {
-                    type: 'string',
-                    format: 'date',
-                    description: `
+            expect(toSchemaObjectOpts.renderedSchemasOpenapi).toEqual(
+              expect.objectContaining({
+                CommentTestingString: {
+                  type: 'object',
+                  required: ['howyadoin'],
+                  properties: {
+                    howyadoin: {
+                      type: 'string',
+                      format: 'date',
+                      description: `
 The following values will be allowed:
   hello,
   world`,
-                    pattern: '/^helloworld$/',
-                    minLength: 2,
-                    maxLength: 4,
+                      pattern: '/^helloworld$/',
+                      minLength: 2,
+                      maxLength: 4,
+                    },
                   },
                 },
-              },
-            }),
-          )
+              }),
+            )
+          })
+        })
+
+        context('with a dream serializer', () => {
+          it('provides the enum values set in the attribute definition', () => {
+            const renderer = new OpenapiEndpointRenderer(
+              PetWithFavoriteTreatsSerializer,
+              UsersController,
+              'howyadoin',
+              {},
+            )
+
+            const toSchemaObjectOpts = defaultToSchemaObjectOpts({
+              renderOpts: { casing: 'camel', suppressResponseEnums: true },
+            })
+            renderer.toSchemaObject(toSchemaObjectOpts)
+
+            expect(toSchemaObjectOpts.renderedSchemasOpenapi).toEqual(
+              expect.objectContaining({
+                PetWithFavoriteTreats: {
+                  type: 'object',
+                  required: ['favoriteTreat', 'favoriteTreats'],
+                  properties: {
+                    favoriteTreats: {
+                      type: ['array', 'null'],
+                      items: {
+                        type: 'string',
+                        description:
+                          'The following values will be allowed:\n' + '  efishy feesh,\n' + '  snick snowcks',
+                      },
+                    },
+                    favoriteTreat: {
+                      type: ['string', 'null'],
+                      description:
+                        'The following values will be allowed:\n' + '  efishy feesh,\n' + '  snick snowcks',
+                    },
+                  },
+                },
+              }),
+            )
+          })
+
+          context('the enum values are explicitly overridden', () => {
+            it('provides the overridden values instead', () => {
+              const renderer = new OpenapiEndpointRenderer(
+                PetWithFavoriteTreatsOverrideSerializer,
+                UsersController,
+                'howyadoin',
+                {},
+              )
+
+              const toSchemaObjectOpts = defaultToSchemaObjectOpts({
+                renderOpts: { casing: 'camel', suppressResponseEnums: true },
+              })
+              renderer.toSchemaObject(toSchemaObjectOpts)
+
+              expect(toSchemaObjectOpts.renderedSchemasOpenapi).toEqual(
+                expect.objectContaining({
+                  PetWithFavoriteTreatsOverride: {
+                    type: 'object',
+                    required: ['favoriteTreat', 'favoriteTreats'],
+                    properties: {
+                      favoriteTreat: {
+                        type: ['string', 'null'],
+                        description:
+                          'The following values will be allowed:\n' +
+                          '  overridden field 1,\n' +
+                          '  overridden field 2',
+                      },
+                      favoriteTreats: {
+                        type: ['array', 'null'],
+                        items: {
+                          type: 'string',
+                          description:
+                            '\n' +
+                            'The following values will be allowed:\n' +
+                            '  overridden field 1,\n' +
+                            '  overridden field 2',
+                        },
+                      },
+                    },
+                  },
+                }),
+              )
+            })
+          })
         })
       })
     })

--- a/test-app/src/app/models/Pet.ts
+++ b/test-app/src/app/models/Pet.ts
@@ -23,6 +23,7 @@ export default class Pet extends ApplicationModel {
   public name: DreamColumn<Pet, 'name'>
   public species: DreamColumn<Pet, 'species'>
   public nonNullSpecies: DreamColumn<Pet, 'nonNullSpecies'>
+  public favoriteTreat: DreamColumn<Pet, 'favoriteTreat'>
   public favoriteTreats: DreamColumn<Pet, 'favoriteTreats'>
   public nonNullFavoriteTreats: DreamColumn<Pet, 'nonNullFavoriteTreats'>
   public collarCount: DreamColumn<Pet, 'collarCount'>

--- a/test-app/src/app/serializers/PetSerializer.ts
+++ b/test-app/src/app/serializers/PetSerializer.ts
@@ -15,3 +15,24 @@ export const PetWithAssociationSerializer = (data: Pet) => DreamSerializer(Pet, 
 
 export const PetWithFlattenedAssociationSerializer = (data: Pet) =>
   DreamSerializer(Pet, data).rendersOne('user', { serializerKey: 'withFlattenedPost' })
+
+export const PetWithFavoriteTreatsSerializer = (pet: Pet) =>
+  DreamSerializer(Pet, pet).attribute('favoriteTreats').attribute('favoriteTreat')
+
+export const PetWithFavoriteTreatsOverrideSerializer = (pet: Pet) =>
+  DreamSerializer(Pet, pet)
+    .attribute('favoriteTreats', {
+      openapi: {
+        type: ['array', 'null'],
+        items: {
+          type: 'string',
+          enum: ['overridden field 1', 'overridden field 2'],
+        },
+      },
+    })
+    .attribute('favoriteTreat', {
+      openapi: {
+        type: ['string', 'null'],
+        enum: ['overridden field 1', 'overridden field 2'],
+      },
+    })

--- a/test-app/src/db/migrations/1683993523103-create-pets.ts
+++ b/test-app/src/db/migrations/1683993523103-create-pets.ts
@@ -16,6 +16,7 @@ export async function up(db: Kysely<any>): Promise<void> {
     .addColumn('likes_walks', 'boolean')
     .addColumn('likes_treats', 'boolean', col => col.notNull().defaultTo(true))
     .addColumn('species', sql`species_types_enum`)
+    .addColumn('favorite_treat', sql`pet_treats_enum`)
     .addColumn('favorite_treats', sql`pet_treats_enum[]`)
     .addColumn('non_null_species', sql`species_types_enum`, col => col.notNull())
     .addColumn('non_null_favorite_treats', sql`pet_treats_enum[]`, col => col.notNull())

--- a/test-app/src/openapi/openapi.json
+++ b/test-app/src/openapi/openapi.json
@@ -2068,6 +2068,17 @@
                     ],
                     "format": "decimal"
                   },
+                  "favoriteTreat": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "efishy feesh",
+                      "snick snowcks",
+                      null
+                    ]
+                  },
                   "favoriteTreats": {
                     "type": [
                       "array",
@@ -2239,6 +2250,17 @@
                       "null"
                     ],
                     "format": "decimal"
+                  },
+                  "favoriteTreat": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "efishy feesh",
+                      "snick snowcks",
+                      null
+                    ]
                   },
                   "favoriteTreats": {
                     "type": [

--- a/test-app/src/types/db.ts
+++ b/test-app/src/types/db.ts
@@ -152,6 +152,7 @@ export interface Pets {
   collarCountInt: number | null;
   collarCountNumeric: Numeric | null;
   createdAt: Timestamp;
+  favoriteTreat: PetTreatsEnum | null;
   favoriteTreats: ArrayType<PetTreatsEnum> | null;
   id: Generated<Int8>;
   lastHeardAt: Generated<Timestamp>;

--- a/test-app/src/types/dream.globals.ts
+++ b/test-app/src/types/dream.globals.ts
@@ -47,6 +47,8 @@ export const globalTypeConfig = {
       'PetSerializer',
       'PetSummarySerializer',
       'PetWithAssociationSerializer',
+      'PetWithFavoriteTreatsOverrideSerializer',
+      'PetWithFavoriteTreatsSerializer',
       'PetWithFlattenedAssociationSerializer',
       'PostSerializer',
       'PostSummarySerializer',

--- a/test-app/src/types/dream.ts
+++ b/test-app/src/types/dream.ts
@@ -323,7 +323,7 @@ export const schema = {
       default: [],
       named: [],
     },
-    nonJsonColumnNames: ['collarCount', 'collarCountInt', 'collarCountNumeric', 'createdAt', 'favoriteTreats', 'id', 'lastHeardAt', 'lastSeenAt', 'likesTreats', 'likesWalks', 'name', 'nonNullFavoriteTreats', 'nonNullSpecies', 'requiredCollarCount', 'requiredCollarCountInt', 'requiredCollarCountNumeric', 'species', 'updatedAt', 'userId'],
+    nonJsonColumnNames: ['collarCount', 'collarCountInt', 'collarCountNumeric', 'createdAt', 'favoriteTreat', 'favoriteTreats', 'id', 'lastHeardAt', 'lastSeenAt', 'likesTreats', 'likesWalks', 'name', 'nonNullFavoriteTreats', 'nonNullSpecies', 'requiredCollarCount', 'requiredCollarCountInt', 'requiredCollarCountNumeric', 'species', 'updatedAt', 'userId'],
     columns: {
       collarCount: {
         coercedType: {} as string | null,
@@ -359,6 +359,15 @@ export const schema = {
         enumValues: null,
         dbType: 'timestamp without time zone',
         allowNull: false,
+        isArray: false,
+      },
+      favoriteTreat: {
+        coercedType: {} as PetTreatsEnum | null,
+        enumType: {} as PetTreatsEnum,
+        enumArrayType: [] as PetTreatsEnum[],
+        enumValues: PetTreatsEnumValues,
+        dbType: 'pet_treats_enum',
+        allowNull: true,
         isArray: false,
       },
       favoriteTreats: {

--- a/test-app/src/types/openapi/openapi.d.ts
+++ b/test-app/src/types/openapi/openapi.d.ts
@@ -1225,6 +1225,8 @@ export interface paths {
                         collarCountInt?: number | null;
                         /** Format: decimal */
                         collarCountNumeric?: number | null;
+                        /** @enum {string|null} */
+                        favoriteTreat?: "efishy feesh" | "snick snowcks" | null;
                         favoriteTreats?: ("efishy feesh" | "snick snowcks")[] | null;
                         /** Format: date-time */
                         lastHeardAt?: string;
@@ -1311,6 +1313,8 @@ export interface paths {
                         collarCountInt?: number | null;
                         /** Format: decimal */
                         collarCountNumeric?: number | null;
+                        /** @enum {string|null} */
+                        favoriteTreat?: "efishy feesh" | "snick snowcks" | null;
                         favoriteTreats?: ("efishy feesh" | "snick snowcks")[] | null;
                         /** Format: date-time */
                         lastHeardAt?: string;


### PR DESCRIPTION
Fix issue with rendering incorrect enum descriptions when suppressResponseEnums is set to true and enums are explicitly overridden in the openapi option.

close https://rvohealth.atlassian.net/browse/PDTC-8582