### PR TITLE
Zustand sync generates store.gen.ts with typed Zustand hooks for each…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1
+
+- fix the `setup:sync:openapi-zustand` CLI command so it generates Zustand stores, not just API shapes
+
 ## 3.1.0
 
 - fix initializers created by sync setup scripts so they don't use npx

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/spec/unit/generate/openapi/reduxBindings.spec.ts
+++ b/spec/unit/generate/openapi/reduxBindings.spec.ts
@@ -181,7 +181,7 @@ export default function initializeMyApi(psy: PsychicApp) {
   psy.on('cli:sync', async () => {
     if (AppEnv.isDevelopmentOrTest) {
       await DreamCLI.logger.logProgress(\`[myApi] syncing...\`, async () => {
-        await DreamCLI.spawn('pnpm exec @rtk-query/codegen-openapi src/conf/openapi/myApi.openapi-codegen.json', {
+        await DreamCLI.spawn('pnpm exec rtk-query-codegen-openapi src/conf/openapi/myApi.openapi-codegen.json', {
           onStdout: message => {
             DreamCLI.logger.logContinueProgress(\`[myApi]\` + ' ' + message, {
               logPrefixColor: 'green',

--- a/spec/unit/generate/openapi/zustandBindings.spec.ts
+++ b/spec/unit/generate/openapi/zustandBindings.spec.ts
@@ -1,6 +1,7 @@
 import { DreamCLI } from '@rvoh/dream/system'
 import fs from 'node:fs/promises'
 import { MockInstance } from 'vitest'
+import generateZustandStoreFromSdk from '../../../../src/generate/helpers/zustandBindings/generateStoreFromSdk.js'
 import generateOpenapiZustandBindings from '../../../../src/generate/openapi/zustandBindings.js'
 
 describe('generateOpenapiZustandBindings', () => {
@@ -87,7 +88,7 @@ client.setConfig({
   })
 
   context('psychic initializer', () => {
-    it('generates a psychic initializer to run @hey-api/openapi-ts on sync', async () => {
+    it('generates a psychic initializer that runs @hey-api/openapi-ts and generates the zustand store on sync', async () => {
       await generateOpenapiZustandBindings({
         exportName: 'myApi',
         schemaFile: './src/openapi/openapi.json',
@@ -99,13 +100,45 @@ client.setConfig({
       expect(contents).toEqual(`\
 import { DreamCLI } from '@rvoh/dream/system'
 import { PsychicApp } from '@rvoh/psychic'
+import { generateZustandStoreFromSdk } from '@rvoh/psychic/system'
 import AppEnv from '../../AppEnv.js'
 
 export default function initializeMyApi(psy: PsychicApp) {
   psy.on('cli:sync', async () => {
     if (AppEnv.isDevelopmentOrTest) {
       await DreamCLI.logger.logProgress(\`[myApi] syncing...\`, async () => {
-        await DreamCLI.spawn('pnpm exec @hey-api/openapi-ts -i ./src/openapi/openapi.json -o ../client/app/api/myApi', {
+        await DreamCLI.spawn('pnpm exec openapi-ts -i ./src/openapi/openapi.json -o ../client/app/api/myApi', {
+          onStdout: message => {
+            DreamCLI.logger.logContinueProgress(\`[myApi]\` + ' ' + message, {
+              logPrefixColor: 'green',
+            })
+          },
+        })
+      })
+
+      await DreamCLI.logger.logProgress(\`[myApi] generating zustand store...\`, async () => {
+        await generateZustandStoreFromSdk('../client/app/api/myApi')
+      })
+    }
+  })
+}`)
+    })
+
+    context('when the initializer already exists without store generation', () => {
+      beforeEach(async () => {
+        await fs.mkdir('test-app/src/conf/initializers/openapi', { recursive: true })
+        await fs.writeFile(
+          'test-app/src/conf/initializers/openapi/myApi.ts',
+          `\
+import { DreamCLI } from '@rvoh/dream/system'
+import { PsychicApp } from '@rvoh/psychic'
+import AppEnv from '../../AppEnv.js'
+
+export default function initializeMyApi(psy: PsychicApp) {
+  psy.on('cli:sync', async () => {
+    if (AppEnv.isDevelopmentOrTest) {
+      await DreamCLI.logger.logProgress(\`[myApi] syncing...\`, async () => {
+        await DreamCLI.spawn('pnpm exec openapi-ts -i ./src/openapi/openapi.json -o ../client/app/api/myApi', {
           onStdout: message => {
             DreamCLI.logger.logContinueProgress(\`[myApi]\` + ' ' + message, {
               logPrefixColor: 'green',
@@ -115,7 +148,51 @@ export default function initializeMyApi(psy: PsychicApp) {
       })
     }
   })
-}`)
+}`,
+        )
+      })
+
+      it('regenerates the initializer to include store generation', async () => {
+        await generateOpenapiZustandBindings({
+          exportName: 'myApi',
+          schemaFile: './src/openapi/openapi.json',
+          outputDir: '../client/app/api/myApi',
+          clientConfigFile: 'test-client/app/api/myApi/client.ts',
+        })
+
+        const contents = (await fs.readFile('test-app/src/conf/initializers/openapi/myApi.ts')).toString()
+        expect(contents).toContain('generateZustandStoreFromSdk')
+      })
+    })
+
+    context('when the initializer already exists and matches the expected output', () => {
+      beforeEach(async () => {
+        // first run to create the initializer
+        await generateOpenapiZustandBindings({
+          exportName: 'myApi',
+          schemaFile: './src/openapi/openapi.json',
+          outputDir: '../client/app/api/myApi',
+          clientConfigFile: 'test-client/app/api/myApi/client.ts',
+        })
+      })
+
+      it('does not regenerate it', async () => {
+        const contentsBefore = (
+          await fs.readFile('test-app/src/conf/initializers/openapi/myApi.ts')
+        ).toString()
+
+        await generateOpenapiZustandBindings({
+          exportName: 'myApi',
+          schemaFile: './src/openapi/openapi.json',
+          outputDir: '../client/app/api/myApi',
+          clientConfigFile: 'test-client/app/api/myApi/client.ts',
+        })
+
+        const contentsAfter = (
+          await fs.readFile('test-app/src/conf/initializers/openapi/myApi.ts')
+        ).toString()
+        expect(contentsAfter).toEqual(contentsBefore)
+      })
     })
   })
 
@@ -127,6 +204,126 @@ export default function initializeMyApi(psy: PsychicApp) {
       })
 
       expect(dreamCliSpy).toHaveBeenCalledWith('pnpm add -D @hey-api/openapi-ts')
+    })
+  })
+})
+
+describe('generateZustandStoreFromSdk', () => {
+  const outputDir = 'test-client/app/api/myApi'
+
+  beforeEach(async () => {
+    await cleanup()
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  async function cleanup() {
+    try {
+      await fs.rm('./test-client', { recursive: true })
+    } catch {
+      // noop
+    }
+  }
+
+  context('when sdk.gen.ts does not exist', () => {
+    it('does nothing', async () => {
+      await generateZustandStoreFromSdk(outputDir)
+
+      await expect(fs.access(`${outputDir}/store.gen.ts`)).rejects.toThrow()
+    })
+  })
+
+  context('when sdk.gen.ts has no exported functions', () => {
+    beforeEach(async () => {
+      await fs.mkdir(outputDir, { recursive: true })
+      await fs.writeFile(`${outputDir}/sdk.gen.ts`, '// empty sdk')
+    })
+
+    it('does nothing', async () => {
+      await generateZustandStoreFromSdk(outputDir)
+
+      await expect(fs.access(`${outputDir}/store.gen.ts`)).rejects.toThrow()
+    })
+  })
+
+  context('when sdk.gen.ts has exported functions', () => {
+    beforeEach(async () => {
+      await fs.mkdir(outputDir, { recursive: true })
+      await fs.writeFile(
+        `${outputDir}/sdk.gen.ts`,
+        `\
+export const getApiUsers = (options?: Options<GetApiUsersData>) => {
+  return (options?.client ?? client).get<GetApiUsersResponse>({
+    url: '/api/users',
+  })
+}
+
+export const postApiUsers = (options: Options<PostApiUsersData>) => {
+  return (options?.client ?? client).post<PostApiUsersResponse>({
+    url: '/api/users',
+    body: options.body,
+  })
+}
+
+export const patchApiUsersById = (options: Options<PatchApiUsersByIdData>) => {
+  return (options?.client ?? client).patch<PatchApiUsersByIdResponse>({
+    url: '/api/users/{id}',
+    path: { id: options.path.id },
+    body: options.body,
+  })
+}`,
+      )
+    })
+
+    it('generates store.gen.ts with a Zustand store hook for each SDK function', async () => {
+      await generateZustandStoreFromSdk(outputDir)
+
+      const contents = (await fs.readFile(`${outputDir}/store.gen.ts`)).toString()
+
+      expect(contents).toContain("import { create } from 'zustand'")
+      expect(contents).toContain("import * as sdk from './sdk.gen'")
+      expect(contents).toContain('export const useGetApiUsers = createSdkStore(sdk.getApiUsers)')
+      expect(contents).toContain('export const usePostApiUsers = createSdkStore(sdk.postApiUsers)')
+      expect(contents).toContain('export const usePatchApiUsersById = createSdkStore(sdk.patchApiUsersById)')
+    })
+
+    it('includes the createSdkStore helper with state management', async () => {
+      await generateZustandStoreFromSdk(outputDir)
+
+      const contents = (await fs.readFile(`${outputDir}/store.gen.ts`)).toString()
+
+      expect(contents).toContain('interface SdkStore<TData, TArgs extends unknown[]>')
+      expect(contents).toContain('data: TData | undefined')
+      expect(contents).toContain('error: unknown')
+      expect(contents).toContain('isLoading: boolean')
+      expect(contents).toContain('fetch: (...args: TArgs) => Promise<TData | undefined>')
+      expect(contents).toContain('reset: () => void')
+      expect(contents).toContain('function createSdkStore')
+    })
+
+    it('regenerates on each call (not skipped if exists)', async () => {
+      await generateZustandStoreFromSdk(outputDir)
+
+      // update sdk.gen.ts with a new function
+      await fs.writeFile(
+        `${outputDir}/sdk.gen.ts`,
+        `\
+export const getApiPets = (options?: Options<GetApiPetsData>) => {
+  return (options?.client ?? client).get<GetApiPetsResponse>({
+    url: '/api/pets',
+  })
+}`,
+      )
+
+      await generateZustandStoreFromSdk(outputDir)
+
+      const contents = (await fs.readFile(`${outputDir}/store.gen.ts`)).toString()
+
+      expect(contents).toContain('export const useGetApiPets = createSdkStore(sdk.getApiPets)')
+      expect(contents).not.toContain('useGetApiUsers')
+      expect(contents).not.toContain('usePostApiUsers')
     })
   })
 })

--- a/src/generate/helpers/reduxBindings/writeInitializer.ts
+++ b/src/generate/helpers/reduxBindings/writeInitializer.ts
@@ -26,7 +26,7 @@ export default async function writeInitializer({ exportName }: { exportName: str
   }
 
   const filePath = path.join('.', 'src', 'conf', 'openapi', `${camelized}.openapi-codegen.json`)
-  const execCmd = PackageManager.exec(`@rtk-query/codegen-openapi ${filePath}`)
+  const execCmd = PackageManager.exec(`rtk-query-codegen-openapi ${filePath}`)
 
   const contents = `\
 import { DreamCLI } from '@rvoh/dream/system'

--- a/src/generate/helpers/zustandBindings/generateStoreFromSdk.ts
+++ b/src/generate/helpers/zustandBindings/generateStoreFromSdk.ts
@@ -1,0 +1,79 @@
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+
+/**
+ * Reads the generated sdk.gen.ts file, extracts exported function names,
+ * and generates a store.gen.ts file with Zustand stores wrapping each
+ * SDK function.
+ *
+ * This is called during `psy sync` after @hey-api/openapi-ts has generated
+ * the SDK, so that the store stays in sync with the API.
+ */
+export default async function generateZustandStoreFromSdk(outputDir: string) {
+  const sdkPath = path.join(outputDir, 'sdk.gen.ts')
+  const storePath = path.join(outputDir, 'store.gen.ts')
+
+  let sdkContents: string
+  try {
+    sdkContents = (await fs.readFile(sdkPath)).toString()
+  } catch {
+    return // sdk.gen.ts doesn't exist yet, nothing to generate from
+  }
+
+  const functionNames = extractExportedFunctionNames(sdkContents)
+  if (functionNames.length === 0) return
+
+  const storeLines = functionNames.map(name => {
+    const hookName = 'use' + name.charAt(0).toUpperCase() + name.slice(1)
+    return `export const ${hookName} = createSdkStore(sdk.${name})`
+  })
+
+  const contents = `\
+// This file is auto-generated during sync — do not edit
+import { create } from 'zustand'
+import * as sdk from './sdk.gen'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SdkFn = (...args: any[]) => Promise<{ data?: any; error?: any }>
+
+interface SdkStore<TData, TArgs extends unknown[]> {
+  data: TData | undefined
+  error: unknown
+  isLoading: boolean
+  fetch: (...args: TArgs) => Promise<TData | undefined>
+  reset: () => void
+}
+
+function createSdkStore<T extends SdkFn>(fn: T) {
+  type TData = Awaited<ReturnType<T>>['data']
+  return create<SdkStore<TData, Parameters<T>>>()((set) => ({
+    data: undefined as TData | undefined,
+    error: undefined as unknown,
+    isLoading: false,
+
+    fetch: async (...args: Parameters<T>) => {
+      set({ isLoading: true, error: undefined })
+      const { data, error } = await (fn as SdkFn)(...args)
+      set({ data, error, isLoading: false })
+      return data as TData | undefined
+    },
+
+    reset: () => set({ data: undefined, error: undefined, isLoading: false }),
+  }))
+}
+
+${storeLines.join('\n')}
+`
+
+  await fs.writeFile(storePath, contents)
+}
+
+function extractExportedFunctionNames(sdkContents: string): string[] {
+  const names: string[] = []
+  const pattern = /export const (\w+)\s*=/g
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(sdkContents)) !== null) {
+    names.push(match[1]!)
+  }
+  return names
+}

--- a/src/generate/helpers/zustandBindings/printFinalStepsMessage.ts
+++ b/src/generate/helpers/zustandBindings/printFinalStepsMessage.ts
@@ -15,22 +15,21 @@ export default function printFinalStepsMessage(opts: Required<OpenapiZustandBind
     color: 'green',
   })
 
-  const zustandLine = colorize(
-    `  const { data } = await getAdminCities()
-    set({ cities: data?.results })`,
-    { color: 'green' },
-  )
+  const storeImportLine = colorize(`+ import { useGetAdminCities } from '${opts.outputDir}/store.gen'`, {
+    color: 'green',
+  })
 
   DreamCLI.logger.log(
     `
 Finished generating @hey-api/openapi-ts bindings for your application.
 
 First, you will need to be sure to sync, so that the typed API functions
-are generated from your openapi schema:
+and Zustand store are generated from your openapi schema:
 
   pnpm psy sync
 
-This will generate typed API functions and types in ${opts.outputDir}/
+This will generate typed API functions in ${opts.outputDir}/sdk.gen.ts
+and a Zustand store in ${opts.outputDir}/store.gen.ts
 
 To use the generated API, first import the client config at your app's
 entry point to configure the base URL and credentials:
@@ -44,17 +43,12 @@ ${sdkImportLine}
 // all functions are fully typed with request params and response types
 ${usageLine}
 
-To use with a Zustand store:
+Or use the auto-generated Zustand store hooks for state management:
 
-import { create } from 'zustand'
-${sdkImportLine}
+${storeImportLine}
 
-const useCitiesStore = create((set) => ({
-  cities: [],
-  fetchCities: async () => {
-${zustandLine}
-  },
-}))
+// each hook provides { data, error, isLoading, fetch, reset }
+const { data, isLoading, fetch } = useGetAdminCities()
 `,
     { logPrefix: '' },
   )

--- a/src/generate/helpers/zustandBindings/writeInitializer.ts
+++ b/src/generate/helpers/zustandBindings/writeInitializer.ts
@@ -15,28 +15,16 @@ export default async function writeInitializer({
 }) {
   const pascalized = pascalize(exportName)
   const camelized = camelize(exportName)
-  const execCmd = PackageManager.exec(`@hey-api/openapi-ts -i ${schemaFile} -o ${outputDir}`)
+  const execCmd = PackageManager.exec(`openapi-ts -i ${schemaFile} -o ${outputDir}`)
 
   const destDir = path.join(psychicPath('conf'), 'initializers', 'openapi')
   const initializerFilename = `${camelized}.ts`
   const initializerPath = path.join(destDir, initializerFilename)
 
-  try {
-    await fs.access(initializerPath)
-    return // early return if the file already exists
-  } catch {
-    // noop
-  }
-
-  try {
-    await fs.access(destDir)
-  } catch {
-    await fs.mkdir(destDir, { recursive: true })
-  }
-
   const contents = `\
 import { DreamCLI } from '@rvoh/dream/system'
 import { PsychicApp } from '@rvoh/psychic'
+import { generateZustandStoreFromSdk } from '@rvoh/psychic/system'
 import AppEnv from '../../AppEnv.js'
 
 export default function initialize${pascalized}(psy: PsychicApp) {
@@ -51,10 +39,29 @@ export default function initialize${pascalized}(psy: PsychicApp) {
           },
         })
       })
+
+      await DreamCLI.logger.logProgress(\`[${camelized}] generating zustand store...\`, async () => {
+        await generateZustandStoreFromSdk('${outputDir}')
+      })
     }
   })
 }\
 `
+
+  try {
+    const existingContents = (await fs.readFile(initializerPath)).toString()
+    if (existingContents === contents) {
+      return // early return if the file already matches exactly
+    }
+  } catch {
+    // noop — file doesn't exist yet
+  }
+
+  try {
+    await fs.access(destDir)
+  } catch {
+    await fs.mkdir(destDir, { recursive: true })
+  }
 
   await fs.writeFile(initializerPath, contents)
 }

--- a/src/generate/openapi/zustandBindings.ts
+++ b/src/generate/openapi/zustandBindings.ts
@@ -15,6 +15,7 @@ import writeInitializer from '../helpers/zustandBindings/writeInitializer.js'
  * * generates the client config file if it does not exist
  * * generates an initializer, which taps into the sync hooks
  *   to automatically run the @hey-api/openapi-ts CLI util
+ *   and generate a zustand store from the SDK output
  * * prints a helpful message, instructing devs on the final
  *   steps for using the generated typed API functions
  *   within their client application.

--- a/src/package-exports/system.ts
+++ b/src/package-exports/system.ts
@@ -1,3 +1,4 @@
+export { default as generateZustandStoreFromSdk } from '../generate/helpers/zustandBindings/generateStoreFromSdk.js'
 export { default as PsychicBin } from '../bin/index.js'
 export { default as PsychicLogos } from '../cli/helpers/PsychicLogos.js'
 export { default as PsychicCLI } from '../cli/index.js'


### PR DESCRIPTION
… SDK function

The Zustand sync generator previously only generated API client code (sdk.gen.ts) but no data store, unlike the Redux generator which produces a full createApi() store. Now `pnpm psy sync` also generates store.gen.ts alongside sdk.gen.ts, with a typed Zustand store hook (e.g. useGetApiUsers) wrapping each SDK function with { data, error, isLoading, fetch, reset } state management.

Also fixes `pnpm exec` commands to use binary names (openapi-ts, rtk-query-codegen-openapi) instead of package names, which don't resolve correctly with pnpm.