### PR TITLE
fix additionalProperties regression, router matches trailing slashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.2.1
+
+- stop injecting `additionalProperties: false` into serializer openapi shapes
+- update the router to
+- generate routes without trailing slash
+- ignore trailing slashes when doing route matching
+
 ## 3.2.0
 
 - new `extractParams` and `extractImplicitParams` primitives on `PsychicController` for narrowing untrusted request params before model writes; `paramsFor` is deprecated in favor of these — `extractParams` requires an explicit allowlist at the call site, `extractImplicitParams` reads the model's declared `paramSafeColumns`. `psy g:resource` / `psy g:controller` scaffolds emit one of these by namespace (`extractImplicitParams` for admin-namespaced resources, `extractParams` with a commented-out list of every implicitly-allowed column elsewhere), overridable via `--with-extract-params` / `--with-extract-implicit-params`

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/spec/unit/openapi-renderer/app/buildOpenapiObject.spec.ts
+++ b/spec/unit/openapi-renderer/app/buildOpenapiObject.spec.ts
@@ -471,7 +471,6 @@ describe('OpenapiAppRenderer', () => {
           expect.objectContaining({
             UserExtra: {
               type: 'object',
-              additionalProperties: false,
               required: ['howyadoin', 'id', 'nicknames'],
               properties: {
                 id: {
@@ -521,7 +520,6 @@ describe('OpenapiAppRenderer', () => {
           expect.objectContaining({
             UserWithPosts: {
               type: 'object',
-              additionalProperties: false,
               required: ['id', 'posts'],
               properties: {
                 id: { type: 'integer' },
@@ -538,7 +536,6 @@ describe('OpenapiAppRenderer', () => {
           expect.objectContaining({
             PostWithComments: {
               type: 'object',
-              additionalProperties: false,
               required: ['body', 'comments', 'id'],
               properties: {
                 id: { type: 'string', format: 'bigint' },
@@ -556,7 +553,6 @@ describe('OpenapiAppRenderer', () => {
           expect.objectContaining({
             Comment: {
               type: 'object',
-              additionalProperties: false,
               required: ['body', 'id'],
               properties: {
                 id: { type: 'string', format: 'bigint' },
@@ -570,7 +566,6 @@ describe('OpenapiAppRenderer', () => {
           expect.objectContaining({
             CommentTestingBasicSerializerRef: {
               type: 'object',
-              additionalProperties: false,
               required: ['howyadoin'],
               properties: {
                 howyadoin: {
@@ -585,7 +580,6 @@ describe('OpenapiAppRenderer', () => {
           expect.objectContaining({
             BalloonLatex: {
               type: 'object',
-              additionalProperties: false,
               required: ['color', 'id', 'latexOnlyAttr'],
               properties: {
                 color: {
@@ -608,7 +602,6 @@ describe('OpenapiAppRenderer', () => {
           expect.objectContaining({
             BalloonMylar: {
               type: 'object',
-              additionalProperties: false,
               required: ['color', 'id', 'mylarOnlyAttr'],
               properties: {
                 color: {
@@ -732,7 +725,6 @@ describe('OpenapiAppRenderer', () => {
         const response = OpenapiAppRenderer.toObject()
         const comment1Content = {
           type: 'object',
-          additionalProperties: false,
           required: ['howyadoin'],
           properties: { howyadoin: { type: 'string', format: 'date' } },
         }

--- a/spec/unit/openapi-renderer/endpoint/toSchemaObject.spec.ts
+++ b/spec/unit/openapi-renderer/endpoint/toSchemaObject.spec.ts
@@ -76,7 +76,6 @@ describe('OpenapiEndpointRenderer', () => {
         UserExtra: {
           type: 'object',
           required: ['howyadoin', 'id', 'nicknames'],
-          additionalProperties: false,
           properties: {
             id: {
               type: 'integer',
@@ -145,7 +144,6 @@ describe('OpenapiEndpointRenderer', () => {
             },
           },
           required: ['color', 'id', 'latexOnlyAttr'],
-          additionalProperties: false,
           type: 'object',
         },
 
@@ -164,7 +162,6 @@ describe('OpenapiEndpointRenderer', () => {
             },
           },
           required: ['color', 'id', 'mylarOnlyAttr'],
-          additionalProperties: false,
           type: 'object',
         },
       })
@@ -199,7 +196,6 @@ describe('OpenapiEndpointRenderer', () => {
             },
           },
           required: ['color', 'id', 'latexOnlyAttr'],
-          additionalProperties: false,
           type: 'object',
         },
         ViewModelsMyViewModel: {
@@ -212,7 +208,6 @@ describe('OpenapiEndpointRenderer', () => {
             },
           },
           required: ['favoriteNumber', 'name'],
-          additionalProperties: false,
           type: 'object',
         },
         BalloonMylar: {
@@ -230,7 +225,6 @@ describe('OpenapiEndpointRenderer', () => {
             },
           },
           required: ['color', 'id', 'mylarOnlyAttr'],
-          additionalProperties: false,
           type: 'object',
         },
 
@@ -248,7 +242,6 @@ describe('OpenapiEndpointRenderer', () => {
             },
           },
           required: ['customAttributeTest', 'id', 'name'],
-          additionalProperties: false,
           type: 'object',
         },
       })
@@ -265,7 +258,6 @@ describe('OpenapiEndpointRenderer', () => {
         BalloonLatex: {
           type: 'object',
           required: ['color', 'id', 'latexOnlyAttr'],
-          additionalProperties: false,
           properties: {
             color: { type: ['string', 'null'], enum: ['blue', 'green', 'red', null] },
             id: { type: 'string', format: 'bigint' },
@@ -292,7 +284,6 @@ describe('OpenapiEndpointRenderer', () => {
             CommentTestingString: {
               type: 'object',
               required: ['howyadoin'],
-              additionalProperties: false,
               properties: {
                 howyadoin: {
                   type: 'string',
@@ -328,7 +319,6 @@ describe('OpenapiEndpointRenderer', () => {
                 CommentTestingString: {
                   type: 'object',
                   required: ['howyadoin'],
-                  additionalProperties: false,
                   properties: {
                     howyadoin: {
                       type: 'string',
@@ -367,7 +357,6 @@ The following values will be allowed:
                 PetWithFavoriteTreats: {
                   type: 'object',
                   required: ['favoriteTreat', 'favoriteTreats'],
-                  additionalProperties: false,
                   properties: {
                     favoriteTreats: {
                       type: ['array', 'null'],
@@ -407,7 +396,6 @@ The following values will be allowed:
                   PetWithFavoriteTreatsOverride: {
                     type: 'object',
                     required: ['favoriteTreat', 'favoriteTreats'],
-                    additionalProperties: false,
                     properties: {
                       favoriteTreat: {
                         type: ['string', 'null'],
@@ -454,7 +442,6 @@ The following values will be allowed:
             CommentTestingInteger: {
               type: 'object',
               required: ['howyadoin'],
-              additionalProperties: false,
               properties: {
                 howyadoin: {
                   type: 'integer',
@@ -484,7 +471,6 @@ The following values will be allowed:
               CommentTestingIntegerShorthand: {
                 type: 'object',
                 required: ['howyadoin'],
-                additionalProperties: false,
                 properties: {
                   howyadoin: {
                     type: 'integer',
@@ -514,7 +500,6 @@ The following values will be allowed:
             CommentTestingDecimal: {
               type: 'object',
               required: ['howyadoin'],
-              additionalProperties: false,
               properties: {
                 howyadoin: {
                   type: 'number',
@@ -545,7 +530,6 @@ The following values will be allowed:
               CommentTestingDecimalShorthand: {
                 type: 'object',
                 required: ['howyadoin'],
-                additionalProperties: false,
                 properties: {
                   howyadoin: {
                     type: 'number',
@@ -576,7 +560,6 @@ The following values will be allowed:
             CommentTestingDate: {
               type: 'object',
               required: ['howyadoin', 'howyadoins'],
-              additionalProperties: false,
               properties: {
                 howyadoin: {
                   type: 'string',
@@ -613,7 +596,6 @@ The following values will be allowed:
             CommentTestingDateTime: {
               type: 'object',
               required: ['howyadoin', 'howyadoins'],
-              additionalProperties: false,
               properties: {
                 howyadoin: {
                   type: 'string',
@@ -660,7 +642,6 @@ The following values will be allowed:
                 'nonNullableHowyadoins',
                 'singleHowyadoin',
               ],
-              additionalProperties: false,
               properties: {
                 nonNullableHowyadoin: {
                   $ref: '#/components/schemas/CommentTestingDecimalShorthand',
@@ -709,7 +690,6 @@ The following values will be allowed:
             CommentTestingDefaultNullFields: {
               type: 'object',
               required: ['howyadoin'],
-              additionalProperties: false,
               properties: {
                 howyadoin: {
                   oneOf: [{ type: 'null' }, { type: 'string' }],
@@ -737,7 +717,6 @@ The following values will be allowed:
             CommentTestingDefaultObjectFields: {
               type: 'object',
               required: ['howyadoin'],
-              additionalProperties: false,
               properties: {
                 howyadoin: {
                   type: 'object',
@@ -767,7 +746,6 @@ The following values will be allowed:
             CommentWithAnyOfObject: {
               type: 'object',
               required: ['howyadoin'],
-              additionalProperties: false,
               properties: {
                 howyadoin: {
                   anyOf: [{ type: 'string' }, { type: 'boolean' }],
@@ -792,7 +770,6 @@ The following values will be allowed:
             CommentWithAllOfObject: {
               type: 'object',
               required: ['howyadoin'],
-              additionalProperties: false,
               properties: {
                 howyadoin: {
                   allOf: [{ type: 'string' }, { type: 'boolean' }],
@@ -817,7 +794,6 @@ The following values will be allowed:
             CommentWithOneOfObject: {
               type: 'object',
               required: ['howyadoin'],
-              additionalProperties: false,
               properties: {
                 howyadoin: {
                   oneOf: [{ type: 'string' }, { type: 'boolean' }],
@@ -842,7 +818,6 @@ The following values will be allowed:
             CommentTestingObjectWithSerializerRef: {
               type: 'object',
               required: ['howyadoin'],
-              additionalProperties: false,
               properties: {
                 howyadoin: {
                   type: 'object',
@@ -896,7 +871,6 @@ The following values will be allowed:
                 CommentWithAnyOfArray: {
                   type: 'object',
                   required: ['howyadoin'],
-                  additionalProperties: false,
                   properties: {
                     howyadoin: {
                       type: 'array',
@@ -926,7 +900,6 @@ The following values will be allowed:
                 CommentWithAllOfArray: {
                   type: 'object',
                   required: ['howyadoin'],
-                  additionalProperties: false,
                   properties: {
                     howyadoin: {
                       type: 'array',
@@ -956,7 +929,6 @@ The following values will be allowed:
                 CommentWithOneOfArray: {
                   type: 'object',
                   required: ['howyadoin'],
-                  additionalProperties: false,
                   properties: {
                     howyadoin: {
                       type: 'array',
@@ -995,14 +967,12 @@ The following values will be allowed:
                 },
               },
               required: ['howyadoin'],
-              additionalProperties: false,
               type: 'object',
             },
 
             CommentTestingObjectWithSerializerRef: {
               type: 'object',
               required: ['howyadoin'],
-              additionalProperties: false,
               properties: {
                 howyadoin: {
                   type: 'object',
@@ -1053,7 +1023,6 @@ The following values will be allowed:
             Pet: {
               type: 'object',
               required: ['customAttributeTest', 'id', 'name'],
-              additionalProperties: false,
               properties: {
                 customAttributeTest: { type: 'string' },
                 id: { type: 'string', format: 'bigint' },
@@ -1063,7 +1032,6 @@ The following values will be allowed:
             User: {
               type: 'object',
               required: ['email', 'id', 'name'],
-              additionalProperties: false,
               properties: {
                 id: { type: 'integer' },
                 email: { type: 'string' },
@@ -1089,7 +1057,6 @@ The following values will be allowed:
               PetWithAssociation: {
                 type: 'object',
                 required: ['user'],
-                additionalProperties: false,
                 properties: {
                   user: { $ref: '#/components/schemas/User' },
                 },
@@ -1097,7 +1064,6 @@ The following values will be allowed:
               User: {
                 type: 'object',
                 required: ['email', 'id', 'name'],
-                additionalProperties: false,
                 properties: {
                   email: { type: 'string' },
                   id: { type: 'integer' },
@@ -1128,7 +1094,6 @@ The following values will be allowed:
               PetWithFlattenedAssociation: {
                 type: 'object',
                 required: ['user'],
-                additionalProperties: false,
                 properties: { user: { $ref: '#/components/schemas/UserWithFlattenedPost' } },
               },
               UserWithFlattenedPost: {
@@ -1136,7 +1101,6 @@ The following values will be allowed:
                   {
                     type: 'object',
                     required: ['id'],
-                    additionalProperties: false,
                     properties: {
                       id: { type: 'integer' },
                     },
@@ -1149,7 +1113,6 @@ The following values will be allowed:
               PostWithComments: {
                 type: 'object',
                 required: ['body', 'comments', 'id'],
-                additionalProperties: false,
                 properties: {
                   body: { type: ['string', 'null'] },
                   comments: {
@@ -1162,7 +1125,6 @@ The following values will be allowed:
               Comment: {
                 type: 'object',
                 required: ['body', 'id'],
-                additionalProperties: false,
                 properties: {
                   body: { type: ['string', 'null'] },
                   id: { type: 'string', format: 'bigint' },
@@ -1186,7 +1148,6 @@ The following values will be allowed:
                 UserWithRecentPost: {
                   type: 'object',
                   required: ['id', 'recentPost'],
-                  additionalProperties: false,
                   properties: {
                     id: { type: 'integer' },
                     recentPost: {
@@ -1213,7 +1174,6 @@ The following values will be allowed:
                 Comment: {
                   type: 'object',
                   required: ['body', 'id'],
-                  additionalProperties: false,
                   properties: {
                     body: { type: ['string', 'null'] },
                     id: { type: 'string', format: 'bigint' },
@@ -1239,7 +1199,6 @@ The following values will be allowed:
               PostWithComments: {
                 type: 'object',
                 required: ['body', 'comments', 'id'],
-                additionalProperties: false,
                 properties: {
                   body: { type: ['string', 'null'] },
                   comments: { type: 'array', items: { $ref: '#/components/schemas/Comment' } },
@@ -1249,7 +1208,6 @@ The following values will be allowed:
               Comment: {
                 type: 'object',
                 required: ['body', 'id'],
-                additionalProperties: false,
                 properties: {
                   body: { type: ['string', 'null'] },
                   id: { type: 'string', format: 'bigint' },
@@ -1273,7 +1231,6 @@ The following values will be allowed:
                 Comment: {
                   type: 'object',
                   required: ['body', 'id'],
-                  additionalProperties: false,
                   properties: {
                     body: { type: ['string', 'null'] },
                     id: { type: 'string', format: 'bigint' },
@@ -1323,7 +1280,6 @@ The following values will be allowed:
             LatexSummary: {
               type: 'object',
               required: ['id', 'latexOnlySummaryAttr'],
-              additionalProperties: false,
               properties: {
                 id: { type: 'string', format: 'bigint' },
                 latexOnlySummaryAttr: {
@@ -1335,7 +1291,6 @@ The following values will be allowed:
             CommentTestingDate: {
               type: 'object',
               required: ['howyadoin', 'howyadoins'],
-              additionalProperties: false,
               properties: {
                 howyadoin: { type: 'string', format: 'date' },
                 howyadoins: { type: 'array', items: { type: 'string', format: 'date' } },
@@ -1345,7 +1300,6 @@ The following values will be allowed:
             CommentTestingBasicArraySerializerRef: {
               type: 'object',
               required: ['howyadoin'],
-              additionalProperties: false,
               properties: {
                 howyadoin: {
                   type: 'array',
@@ -1383,7 +1337,6 @@ The following values will be allowed:
           CommentTestingString: {
             type: 'object',
             required: ['howyadoin'],
-            additionalProperties: false,
             properties: {
               howyadoin: {
                 type: 'string',
@@ -1415,7 +1368,6 @@ The following values will be allowed:
           CommentTestingString: {
             type: 'object',
             required: ['howyadoin'],
-            additionalProperties: false,
             properties: {
               howyadoin: {
                 type: 'string',

--- a/spec/unit/openapi-renderer/serializer/DreamSerializer/customAttribute.spec.ts
+++ b/spec/unit/openapi-renderer/serializer/DreamSerializer/customAttribute.spec.ts
@@ -119,10 +119,10 @@ describe('DreamSerializer customAttributes', () => {
       const serializerOpenapiRenderer = new SerializerOpenapiRenderer(MySerializer)
       const results = serializerOpenapiRenderer.renderedOpenapi()
       expect(results.openapi).toEqual({
+        type: 'object',
         allOf: [
           {
             type: 'object',
-            additionalProperties: false,
             required: ['species'],
             properties: {
               species: { type: ['string', 'null'], enum: [...SpeciesTypesEnumValues, null] },
@@ -132,6 +132,7 @@ describe('DreamSerializer customAttributes', () => {
             $ref: '#/components/schemas/User',
           },
         ],
+        unevaluatedProperties: false,
       })
 
       expect(results.referencedSerializers).toHaveLength(1)
@@ -153,10 +154,10 @@ describe('DreamSerializer customAttributes', () => {
         const serializerOpenapiRenderer = new SerializerOpenapiRenderer(MySerializer)
         const results = serializerOpenapiRenderer.renderedOpenapi()
         expect(results.openapi).toEqual({
+          type: 'object',
           allOf: [
             {
               type: 'object',
-              additionalProperties: false,
               required: ['species'],
               properties: {
                 species: { type: ['string', 'null'], enum: [...SpeciesTypesEnumValues, null] },
@@ -166,6 +167,7 @@ describe('DreamSerializer customAttributes', () => {
               $ref: '#/components/schemas/User',
             },
           ],
+          unevaluatedProperties: false,
         })
 
         expect(results.referencedSerializers).toHaveLength(1)
@@ -188,10 +190,10 @@ describe('DreamSerializer customAttributes', () => {
           const serializerOpenapiRenderer = new SerializerOpenapiRenderer(MySerializer)
           const results = serializerOpenapiRenderer.renderedOpenapi()
           expect(results.openapi).toEqual({
+            type: 'object',
             allOf: [
               {
                 type: 'object',
-                additionalProperties: false,
                 required: ['species'],
                 properties: {
                   species: { type: ['string', 'null'], enum: [...SpeciesTypesEnumValues, null] },
@@ -201,6 +203,7 @@ describe('DreamSerializer customAttributes', () => {
                 $ref: '#/components/schemas/UserSummary',
               },
             ],
+            unevaluatedProperties: false,
           })
 
           expect(results.referencedSerializers).toHaveLength(1)
@@ -220,10 +223,10 @@ describe('DreamSerializer customAttributes', () => {
         const serializerOpenapiRenderer = new SerializerOpenapiRenderer(MySerializer)
         const results = serializerOpenapiRenderer.renderedOpenapi()
         expect(results.openapi).toEqual({
+          type: 'object',
           allOf: [
             {
               type: 'object',
-              additionalProperties: false,
               required: ['species'],
               properties: {
                 species: { type: ['string', 'null'], enum: [...SpeciesTypesEnumValues, null] },
@@ -240,6 +243,7 @@ describe('DreamSerializer customAttributes', () => {
               ],
             },
           ],
+          unevaluatedProperties: false,
         })
 
         expect(results.referencedSerializers).toHaveLength(1)

--- a/spec/unit/openapi-renderer/serializer/DreamSerializer/flattenAllOfValidation.spec.ts
+++ b/spec/unit/openapi-renderer/serializer/DreamSerializer/flattenAllOfValidation.spec.ts
@@ -41,8 +41,7 @@ describe('SerializerOpenapiRenderer flatten allOf payload validation', () => {
     // declares its own `unevaluatedProperties: false`. Without the renderer fix,
     // properties contributed by either branch are rejected as "additional" by the
     // other branch.
-    const SiblingSerializer = (data: User) =>
-      DreamSerializer(User, data).attribute('email').attribute('name')
+    const SiblingSerializer = (data: User) => DreamSerializer(User, data).attribute('email').attribute('name')
     ;(SiblingSerializer as unknown as { globalName: string; openapiName: string }).globalName =
       'FlattenSiblingSerializer'
     ;(SiblingSerializer as unknown as { globalName: string; openapiName: string }).openapiName =

--- a/spec/unit/openapi-renderer/serializer/DreamSerializer/flattenAllOfValidation.spec.ts
+++ b/spec/unit/openapi-renderer/serializer/DreamSerializer/flattenAllOfValidation.spec.ts
@@ -1,0 +1,117 @@
+import { DreamSerializer } from '@rvoh/dream'
+import SerializerOpenapiRenderer from '../../../../../src/openapi-renderer/SerializerOpenapiRenderer.js'
+import { validateObject } from '../../../../../src/helpers/validateOpenApiSchema.js'
+import Pet from '../../../../../test-app/src/app/models/Pet.js'
+import User from '../../../../../test-app/src/app/models/User.js'
+
+describe('SerializerOpenapiRenderer flatten allOf payload validation', () => {
+  it('accepts a payload that includes properties contributed by a flattened literal allOf sibling', () => {
+    const ParentSerializer = (data: Pet) =>
+      DreamSerializer(Pet, data)
+        .attribute('species')
+        .customAttribute('localizedText', () => null, {
+          flatten: true,
+          openapi: {
+            type: 'object',
+            required: ['subtitle', 'title'],
+            properties: {
+              subtitle: { type: ['string', 'null'] },
+              title: { type: ['string', 'null'] },
+            },
+          },
+        })
+
+    const renderer = new SerializerOpenapiRenderer(ParentSerializer)
+    const renderedSchema = renderer.renderedOpenapi().openapi
+
+    const payload = {
+      species: 'cat',
+      subtitle: 'My subtitle',
+      title: 'My title',
+    }
+
+    const result = validateObject(payload, renderedSchema as object, { removeAdditional: false })
+
+    expect(result.errors).toBeUndefined()
+    expect(result.isValid).toBe(true)
+  })
+
+  it('accepts a payload that includes properties from a $ref-bundled flattened sibling whose own schema has a property lock', () => {
+    // Mirrors the wellos failure: an inline branch + a $ref'd sibling schema that
+    // declares its own `unevaluatedProperties: false`. Without the renderer fix,
+    // properties contributed by either branch are rejected as "additional" by the
+    // other branch.
+    const SiblingSerializer = (data: User) =>
+      DreamSerializer(User, data).attribute('email').attribute('name')
+    ;(SiblingSerializer as unknown as { globalName: string; openapiName: string }).globalName =
+      'FlattenSiblingSerializer'
+    ;(SiblingSerializer as unknown as { globalName: string; openapiName: string }).openapiName =
+      'FlattenSibling'
+
+    const ParentSerializer = (data: Pet) =>
+      DreamSerializer(Pet, data)
+        .attribute('species')
+        .customAttribute('flattened', () => null, {
+          flatten: true,
+          openapi: { $serializer: SiblingSerializer },
+        })
+
+    const parentRenderer = new SerializerOpenapiRenderer(ParentSerializer)
+    const parentSchema = parentRenderer.renderedOpenapi().openapi
+
+    const siblingRenderer = new SerializerOpenapiRenderer(SiblingSerializer)
+    const siblingSchema = siblingRenderer.renderedOpenapi().openapi
+
+    const schemaWithComponents = {
+      ...(parentSchema as object),
+      components: {
+        schemas: {
+          FlattenSibling: siblingSchema,
+        },
+      },
+    }
+
+    const payload = {
+      species: 'cat',
+      email: 'a@b.com',
+      name: 'A',
+    }
+
+    const result = validateObject(payload, schemaWithComponents, { removeAdditional: false })
+
+    expect(result.errors).toBeUndefined()
+    expect(result.isValid).toBe(true)
+  })
+
+  it('rejects an unknown property at the wrapper level via unevaluatedProperties', () => {
+    const ParentSerializer = (data: Pet) =>
+      DreamSerializer(Pet, data)
+        .attribute('species')
+        .customAttribute('localizedText', () => null, {
+          flatten: true,
+          openapi: {
+            type: 'object',
+            required: ['subtitle', 'title'],
+            properties: {
+              subtitle: { type: ['string', 'null'] },
+              title: { type: ['string', 'null'] },
+            },
+          },
+        })
+
+    const renderer = new SerializerOpenapiRenderer(ParentSerializer)
+    const renderedSchema = renderer.renderedOpenapi().openapi
+
+    const payload = {
+      species: 'cat',
+      subtitle: 'My subtitle',
+      title: 'My title',
+      somethingMadeUp: 'should be rejected',
+    }
+
+    const result = validateObject(payload, renderedSchema as object, { removeAdditional: false })
+
+    expect(result.isValid).toBe(false)
+    expect(result.errors?.[0]?.params).toMatchObject({ unevaluatedProperty: 'somethingMadeUp' })
+  })
+})

--- a/spec/unit/openapi-renderer/serializer/DreamSerializer/rendersMany.spec.ts
+++ b/spec/unit/openapi-renderer/serializer/DreamSerializer/rendersMany.spec.ts
@@ -176,7 +176,6 @@ describe('DreamSerializer rendersMany', () => {
               },
             },
           },
-          additionalProperties: false,
         })
       })
     })

--- a/spec/unit/openapi-renderer/serializer/DreamSerializer/rendersOne.spec.ts
+++ b/spec/unit/openapi-renderer/serializer/DreamSerializer/rendersOne.spec.ts
@@ -103,10 +103,10 @@ describe('DreamSerializer rendersOne', () => {
       const serializerOpenapiRenderer = new SerializerOpenapiRenderer(MySerializer)
       const results = serializerOpenapiRenderer.renderedOpenapi()
       expect(results.openapi).toEqual({
+        type: 'object',
         allOf: [
           {
             type: 'object',
-            additionalProperties: false,
             required: ['species'],
             properties: {
               species: { type: ['string', 'null'], enum: [...SpeciesTypesEnumValues, null] },
@@ -116,6 +116,7 @@ describe('DreamSerializer rendersOne', () => {
             $ref: '#/components/schemas/User',
           },
         ],
+        unevaluatedProperties: false,
       })
 
       expect(results.referencedSerializers).toHaveLength(1)
@@ -132,10 +133,10 @@ describe('DreamSerializer rendersOne', () => {
         const serializerOpenapiRenderer = new SerializerOpenapiRenderer(MySerializer)
         const results = serializerOpenapiRenderer.renderedOpenapi()
         expect(results.openapi).toEqual({
+          type: 'object',
           allOf: [
             {
               type: 'object',
-              additionalProperties: false,
               required: ['species'],
               properties: {
                 species: { type: ['string', 'null'], enum: [...SpeciesTypesEnumValues, null] },
@@ -152,6 +153,7 @@ describe('DreamSerializer rendersOne', () => {
               ],
             },
           ],
+          unevaluatedProperties: false,
         })
 
         expect(results.referencedSerializers).toHaveLength(1)
@@ -176,7 +178,6 @@ describe('DreamSerializer rendersOne', () => {
               $ref: '#/components/schemas/User',
             },
           },
-          additionalProperties: false,
         })
       })
     })

--- a/spec/unit/openapi-renderer/serializer/ObjectSerializer/rendersMany.spec.ts
+++ b/spec/unit/openapi-renderer/serializer/ObjectSerializer/rendersMany.spec.ts
@@ -117,7 +117,6 @@ describe('ObjectSerializer rendersMany', () => {
                 },
               },
             },
-            additionalProperties: false,
           })
         })
       })

--- a/spec/unit/openapi-renderer/serializer/ObjectSerializer/rendersOne.spec.ts
+++ b/spec/unit/openapi-renderer/serializer/ObjectSerializer/rendersOne.spec.ts
@@ -115,7 +115,6 @@ describe('ObjectSerializer rendersOne', () => {
                 $ref: '#/components/schemas/User',
               },
             },
-            additionalProperties: false,
           })
         })
       })
@@ -130,10 +129,10 @@ describe('ObjectSerializer rendersOne', () => {
 
         const serializerOpenapiRenderer = new SerializerOpenapiRenderer(MySerializer)
         expect(serializerOpenapiRenderer.renderedOpenapi().openapi).toEqual({
+          type: 'object',
           allOf: [
             {
               type: 'object',
-              additionalProperties: false,
               required: ['species'],
               properties: {
                 species: { type: ['string', 'null'], enum: SpeciesTypesEnumValues },
@@ -143,6 +142,7 @@ describe('ObjectSerializer rendersOne', () => {
               $ref: '#/components/schemas/User',
             },
           ],
+          unevaluatedProperties: false,
         })
       })
     })

--- a/spec/unit/openapi-renderer/serializer/ObjectSerializer/view-models/customAttribute.spec.ts
+++ b/spec/unit/openapi-renderer/serializer/ObjectSerializer/view-models/customAttribute.spec.ts
@@ -44,10 +44,10 @@ describe('ObjectSerializer (on a view model) customAttribute', () => {
 
       const serializerOpenapiRenderer = new SerializerOpenapiRenderer(MySerializer)
       expect(serializerOpenapiRenderer.renderedOpenapi().openapi).toEqual({
+        type: 'object',
         allOf: [
           {
             type: 'object',
-            additionalProperties: false,
             required: ['name'],
             properties: {
               name: { type: 'string' },
@@ -57,6 +57,7 @@ describe('ObjectSerializer (on a view model) customAttribute', () => {
             $ref: '#/components/schemas/ViewModelsMyViewModel',
           },
         ],
+        unevaluatedProperties: false,
       })
     })
   })

--- a/spec/unit/openapi-renderer/serializer/ObjectSerializer/view-models/rendersOne.spec.ts
+++ b/spec/unit/openapi-renderer/serializer/ObjectSerializer/view-models/rendersOne.spec.ts
@@ -60,10 +60,10 @@ describe('ObjectSerializer (on a view model) rendersOne', () => {
 
       const serializerOpenapiRenderer = new SerializerOpenapiRenderer(MySerializer)
       expect(serializerOpenapiRenderer.renderedOpenapi().openapi).toEqual({
+        type: 'object',
         allOf: [
           {
             type: 'object',
-            additionalProperties: false,
             required: ['name'],
             properties: {
               name: { type: 'string' },
@@ -73,6 +73,7 @@ describe('ObjectSerializer (on a view model) rendersOne', () => {
             $ref: '#/components/schemas/ViewModelsMyViewModel',
           },
         ],
+        unevaluatedProperties: false,
       })
     })
   })

--- a/spec/unit/router/trailing-slash.spec.ts
+++ b/spec/unit/router/trailing-slash.spec.ts
@@ -1,0 +1,95 @@
+import { agent as supertest } from 'supertest'
+import PsychicRouter from '../../../src/router/index.js'
+import PsychicServer from '../../../src/server/index.js'
+import UsersController from '../../../test-app/src/app/controllers/UsersController.js'
+
+describe('PsychicRouter trailing slash handling', () => {
+  describe('registered path', () => {
+    let server: PsychicServer
+    let router: PsychicRouter
+
+    beforeEach(() => {
+      server = new PsychicServer()
+      router = new PsychicRouter(server.koaApp)
+    })
+
+    it('does not append a trailing slash when an empty path is registered inside a namespace', () => {
+      router.namespace('foo', r => {
+        r.put('', UsersController, 'ping')
+      })
+      router.commit()
+
+      expect(router.routes).toEqual(
+        expect.arrayContaining([
+          {
+            httpMethod: 'put',
+            path: '/foo',
+            controller: UsersController,
+            action: 'ping',
+          },
+        ]),
+      )
+    })
+
+    it('does not append a trailing slash when an empty path is registered inside nested namespaces', () => {
+      router.namespace('a', r => {
+        r.namespace('b', r => {
+          r.namespace('c', r => {
+            r.get('', UsersController, 'ping')
+            r.post('', UsersController, 'ping')
+          })
+        })
+      })
+      router.commit()
+
+      expect(router.routes).toEqual(
+        expect.arrayContaining([
+          {
+            httpMethod: 'get',
+            path: '/a/b/c',
+            controller: UsersController,
+            action: 'ping',
+          },
+          {
+            httpMethod: 'post',
+            path: '/a/b/c',
+            controller: UsersController,
+            action: 'ping',
+          },
+        ]),
+      )
+    })
+  })
+
+  it('matches a route registered inside a namespace with an empty path when called WITH a trailing slash', async () => {
+    const server = new PsychicServer()
+    await server.boot()
+
+    const res = await supertest(server.koaApp.callback()).put('/trailing-slash-test/').expect(200)
+    expect(res.body).toEqual('helloworld')
+  })
+
+  it('matches a route registered inside a namespace with an empty path when called WITHOUT a trailing slash', async () => {
+    const server = new PsychicServer()
+    await server.boot()
+
+    const res = await supertest(server.koaApp.callback()).put('/trailing-slash-test').expect(200)
+    expect(res.body).toEqual('helloworld')
+  })
+
+  it('matches a GET route registered inside a namespace with an empty path WITHOUT a trailing slash', async () => {
+    const server = new PsychicServer()
+    await server.boot()
+
+    const res = await supertest(server.koaApp.callback()).get('/trailing-slash-test').expect(200)
+    expect(res.body).toEqual('helloworld')
+  })
+
+  it('matches a POST route registered inside a namespace with an empty path WITHOUT a trailing slash', async () => {
+    const server = new PsychicServer()
+    await server.boot()
+
+    const res = await supertest(server.koaApp.callback()).post('/trailing-slash-test').expect(200)
+    expect(res.body).toEqual('helloworld')
+  })
+})

--- a/src/helpers/validateOpenApiSchema.ts
+++ b/src/helpers/validateOpenApiSchema.ts
@@ -1,4 +1,5 @@
-import { Ajv, type ErrorObject, type JSONSchemaType, type ValidateFunction } from 'ajv'
+import { type ErrorObject, type JSONSchemaType, type ValidateFunction } from 'ajv'
+import { Ajv2020 } from 'ajv/dist/2020.js'
 import addFormats from 'ajv-formats'
 
 /**
@@ -113,7 +114,7 @@ export function createValidator<T = unknown>(
     init: undefined,
   }
 
-  const ajv = new Ajv({
+  const ajv = new Ajv2020({
     removeAdditional: false,
     useDefaults: true,
     strict: false,
@@ -178,9 +179,9 @@ export interface ValidationError {
   params?: Record<string, unknown>
 }
 
-export type AjvValidationOpts = ConstructorParameters<typeof Ajv>[0]
+export type AjvValidationOpts = ConstructorParameters<typeof Ajv2020>[0]
 export type ValidateOpenapiSchemaOptions = AjvValidationOpts & CustomOpenapiValidationOptions
 
 export interface CustomOpenapiValidationOptions {
-  init?: (ajv: Ajv) => void
+  init?: (ajv: Ajv2020) => void
 }

--- a/src/openapi-renderer/SerializerOpenapiRenderer.ts
+++ b/src/openapi-renderer/SerializerOpenapiRenderer.ts
@@ -92,13 +92,16 @@ export default class SerializerOpenapiRenderer {
     )
 
     if (this.allOfSiblings.length) {
-      const openapi = referencedSerializersAndOpenapiSchemaBodyShorthand.openapi
-
+      // Property-level locks live only at the `allOf` wrapper (never on the
+      // inline branch or the `$ref`'d siblings) so that all branches'
+      // properties are visible to `unevaluatedProperties` for the union check.
       return {
         ...referencedSerializersAndOpenapiSchemaBodyShorthand,
         openapi: {
-          allOf: [openapi, ...this.allOfSiblings],
-        },
+          type: 'object',
+          allOf: [referencedSerializersAndOpenapiSchemaBodyShorthand.openapi, ...this.allOfSiblings],
+          unevaluatedProperties: false,
+        } as OpenapiSchemaBodyShorthand,
       }
     } else {
       return referencedSerializersAndOpenapiSchemaBodyShorthand
@@ -146,7 +149,13 @@ export default class SerializerOpenapiRenderer {
         type: 'object',
         required: sort(uniq(requiredProperties.map(property => this.setCase(property)))),
         properties: sortObjectByKey(referencedSerializersAndAttributes.attributes),
-        additionalProperties: false,
+        // Property-level locks (`additionalProperties` / `unevaluatedProperties`)
+        // are not emitted on leaf schemas: when a leaf is composed via `$ref`
+        // inside an `allOf`, neither keyword sees properties contributed by
+        // sibling branches, so a per-leaf lock incorrectly rejects flattened
+        // properties. Strictness is enforced at the `allOf`-wrapper level
+        // (`unevaluatedProperties: false`) when flattening occurs, and at the
+        // validation-pipeline level for top-level schemas.
       },
     }
   }

--- a/src/router/helpers.ts
+++ b/src/router/helpers.ts
@@ -9,7 +9,9 @@ import PsychicRouter from '../router/index.js'
 import { HttpMethod, ResourcesMethodType, ResourcesOptions } from './types.js'
 
 export function routePath(routePath: string) {
-  return `/${routePath.replace(/^\//, '')}`
+  const normalized = `/${routePath.replace(/^\//, '')}`
+  if (normalized === '/') return normalized
+  return normalized.replace(/\/+$/, '')
 }
 
 export function resourcePath(routePath: string) {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -166,7 +166,8 @@ export default class PsychicRouter {
 
   private prefixPathWithNamespaces(str: string) {
     if (!this.currentNamespaces.length) return str
-    return '/' + this.currentNamespacePaths.join('/') + '/' + str
+    const prefix = '/' + this.currentNamespacePaths.join('/')
+    return str ? `${prefix}/${str}` : prefix
   }
 
   public crud(httpMethod: HttpMethod, path: string): void

--- a/test-app/src/conf/routes.ts
+++ b/test-app/src/conf/routes.ts
@@ -290,6 +290,14 @@ export default function routes(r: PsychicRouter) {
     })
   })
 
+  // routes registered with an empty path inside a namespace; used to verify
+  // that requests match regardless of trailing slash on the request URL
+  r.namespace('trailing-slash-test', r => {
+    r.get('', UsersController, 'ping')
+    r.put('', UsersController, 'ping')
+    r.post('', UsersController, 'ping')
+  })
+
   // NOTE: passport integration requires koa-passport for Koa compatibility
   r.post('passport-test', [
     passport.authenticate('local'),

--- a/test-app/src/openapi/admin.openapi.json
+++ b/test-app/src/openapi/admin.openapi.json
@@ -400,7 +400,6 @@
     "schemas": {
       "Availability": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "end",
           "endtz",
@@ -455,7 +454,6 @@
       },
       "Comment1OnlyUsedInOneController": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "howyadoin"
         ],
@@ -468,7 +466,6 @@
       },
       "Comment2OnlyUsedInOneController": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "howyadoin"
         ],

--- a/test-app/src/openapi/mobile.openapi.json
+++ b/test-app/src/openapi/mobile.openapi.json
@@ -240,7 +240,6 @@
     "schemas": {
       "Availability": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "end",
           "endtz",
@@ -295,7 +294,6 @@
       },
       "Comment1OnlyUsedInOneController": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "howyadoin"
         ],
@@ -308,7 +306,6 @@
       },
       "Comment2OnlyUsedInOneController": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "howyadoin"
         ],

--- a/test-app/src/openapi/openapi.json
+++ b/test-app/src/openapi/openapi.json
@@ -6514,7 +6514,6 @@
     "schemas": {
       "BalloonLatex": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "color",
           "id",
@@ -6544,7 +6543,6 @@
       },
       "BalloonMylar": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "color",
           "id",
@@ -6574,7 +6572,6 @@
       },
       "CircularHello": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "user",
           "world"
@@ -6590,7 +6587,6 @@
       },
       "CircularWorld": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "hello"
         ],
@@ -6602,7 +6598,6 @@
       },
       "Comment": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "body",
           "id"
@@ -6622,7 +6617,6 @@
       },
       "CommentTestingBasicSerializerRef": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "howyadoin"
         ],
@@ -6645,7 +6639,6 @@
       },
       "LatexSummary": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "id",
           "latexOnlySummaryAttr"
@@ -6717,7 +6710,6 @@
       },
       "Pet": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "customAttributeTest",
           "id",
@@ -6741,7 +6733,6 @@
       },
       "PetAdditional": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "customAttributeTest",
           "id",
@@ -6762,7 +6753,6 @@
       },
       "PostWithComments": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "body",
           "comments",
@@ -6789,7 +6779,6 @@
       },
       "User": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "email",
           "id",
@@ -6812,7 +6801,6 @@
       },
       "UserExtra": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "howyadoin",
           "id",
@@ -6864,7 +6852,6 @@
       },
       "UserSummary": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "id"
         ],
@@ -6876,7 +6863,6 @@
       },
       "UserWithPosts": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "id",
           "posts"
@@ -6919,7 +6905,6 @@
       },
       "ViewModelsMyViewModel": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "favoriteNumber",
           "name"


### PR DESCRIPTION
`additionalProperties: false` only sees properties declared in the same subschema, so when a flatten serializer produced
`{ allOf: [inline, $ref] }` with the inline branch (or the $ref'd sibling) locked, AJV rejected any property contributed by the other branch — e.g. response validation for a Dream serializer flattening a localized-text serializer would fail with `additionalProperty: 'subtitle'` even though the $ref'd schema declared `subtitle`.

- SerializerOpenapiRenderer: leaf schemas no longer emit `additionalProperties: false`; the allOf wrapper added for flatten siblings now emits `type: 'object'` + `unevaluatedProperties: false`, which composes correctly across allOf branches.
- validateOpenApiSchema: switch to `Ajv2020` so `unevaluatedProperties` is honored (default Ajv is draft-07 and silently ignores it).
- Update existing snapshot specs and add coverage for the failure mode (literal sibling, $ref'd sibling, wrapper-level unknown-property rejection).

Additionally, update the router to
 * generate routes without trailing slash
 * ignore trailing slashes when doing route matching

close https://rvohealth.atlassian.net/browse/WLOS-2752
close https://rvohealth.atlassian.net/browse/WLOS-2782