### PR TITLE
Generator cleanup cluster: belongs_to @alias support in resource generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 3.4.0
+## 3.5.0
 
-- the resource generator (`psy g:resource`) now accepts the `Model@alias:belongs_to[:optional]` shorthand that the dream generators added in 2.10.0. The aliased camelCase property name flows through `parseAttribute` into `generateResourceControllerSpecContent` and `paramSafeColumnNamesFromCliTokens` transparently, so spec scaffolds reference the alias and the controller param allowlist correctly excludes aliased FK fields. Examples: `InternalUser@canceled_by:belongs_to:optional`, `Messaging/Template@template:belongs_to` (strips the namespace from the property/association names while keeping the namespaced model reference intact). Old `Model:belongs_to` form continues to work unchanged
+- improvements to `psy g:resource`'s `belongs_to` shorthand
 
 ## 3.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.5.0
+## 3.4.0
 
 - improvements to `psy g:resource`'s `belongs_to` shorthand
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.4.0
+
+- the resource generator (`psy g:resource`) now accepts the `Model@alias:belongs_to[:optional]` shorthand that the dream generators added in 2.10.0. The aliased camelCase property name flows through `parseAttribute` into `generateResourceControllerSpecContent` and `paramSafeColumnNamesFromCliTokens` transparently, so spec scaffolds reference the alias and the controller param allowlist correctly excludes aliased FK fields. Examples: `InternalUser@canceled_by:belongs_to:optional`, `Messaging/Template@template:belongs_to` (strips the namespace from the property/association names while keeping the namespaced model reference intact). Old `Model:belongs_to` form continues to work unchanged
+
 ## 3.3.0
 
 - recursive Dream-model-driven request bodies via a nested `for:` sentinel inside `requestBody.combining` / `properties` / `items` — produces an inline object schema derived from the model's param-safe columns, recurses through further `combining`, and is request-only (response shorthand still uses `$serializable` / `$serializer`)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.5.0",
+  "version": "3.4.0",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/spec/unit/generate/helpers/paramSafeColumnNamesFromCliTokens.spec.ts
+++ b/spec/unit/generate/helpers/paramSafeColumnNamesFromCliTokens.spec.ts
@@ -26,13 +26,13 @@ describe('paramSafeColumnNamesFromCliTokens', () => {
   })
 
   it('filters belongs_to relationships with @alias rename', () => {
-    // Important: the aliased FK property name (cancelledBy) must NOT leak into
+    // Important: the aliased FK property name (canceledBy) must NOT leak into
     // the paramSafe allowlist any more than the legacy form does. The filter
     // is by attributeType === 'belongs_to', so it catches both forms.
     expect(
       paramSafeColumnNamesFromCliTokens([
         'subject:string',
-        'InternalUser@cancelled_by:belongs_to:optional',
+        'InternalUser@canceled_by:belongs_to:optional',
         'Messaging/Message@last_inbound_message:belongs_to:optional',
       ]),
     ).toEqual(['subject'])

--- a/spec/unit/generate/helpers/paramSafeColumnNamesFromCliTokens.spec.ts
+++ b/spec/unit/generate/helpers/paramSafeColumnNamesFromCliTokens.spec.ts
@@ -1,0 +1,46 @@
+import paramSafeColumnNamesFromCliTokens from '../../../../src/generate/helpers/paramSafeColumnNamesFromCliTokens.js'
+
+describe('paramSafeColumnNamesFromCliTokens', () => {
+  it('camelizes scalar attribute names', () => {
+    expect(paramSafeColumnNamesFromCliTokens(['phone_number:string', 'email:string'])).toEqual([
+      'phoneNumber',
+      'email',
+    ])
+  })
+
+  it('filters reserved column names', () => {
+    expect(
+      paramSafeColumnNamesFromCliTokens([
+        'name:string',
+        'id:integer',
+        'created_at:datetime',
+        'updated_at:datetime',
+        'deleted_at:datetime',
+        'type:string',
+      ]),
+    ).toEqual(['name'])
+  })
+
+  it('filters belongs_to relationships (legacy form)', () => {
+    expect(paramSafeColumnNamesFromCliTokens(['name:string', 'User:belongs_to'])).toEqual(['name'])
+  })
+
+  it('filters belongs_to relationships with @alias rename', () => {
+    // Important: the aliased FK property name (cancelledBy) must NOT leak into
+    // the paramSafe allowlist any more than the legacy form does. The filter
+    // is by attributeType === 'belongs_to', so it catches both forms.
+    expect(
+      paramSafeColumnNamesFromCliTokens([
+        'subject:string',
+        'InternalUser@cancelled_by:belongs_to:optional',
+        'Messaging/Message@last_inbound_message:belongs_to:optional',
+      ]),
+    ).toEqual(['subject'])
+  })
+
+  it('filters polymorphic _type and _id suffix columns', () => {
+    expect(paramSafeColumnNamesFromCliTokens(['name:string', 'owner_type:string', 'owner_id:uuid'])).toEqual([
+      'name',
+    ])
+  })
+})

--- a/spec/unit/generate/helpers/parseAttribute.spec.ts
+++ b/spec/unit/generate/helpers/parseAttribute.spec.ts
@@ -67,8 +67,8 @@ describe('parseAttribute (psychic)', () => {
 
   context('belongs_to with @alias (new form)', () => {
     it('uses the camelized alias as the attribute name', () => {
-      expect(parseAttribute('InternalUser@cancelled_by:belongs_to')).toEqual({
-        attributeName: 'cancelledBy',
+      expect(parseAttribute('InternalUser@canceled_by:belongs_to')).toEqual({
+        attributeName: 'canceledBy',
         attributeType: 'belongs_to',
         isArray: false,
         enumValues: undefined,

--- a/spec/unit/generate/helpers/parseAttribute.spec.ts
+++ b/spec/unit/generate/helpers/parseAttribute.spec.ts
@@ -1,0 +1,127 @@
+import parseAttribute from '../../../../src/generate/helpers/parseAttribute.js'
+
+describe('parseAttribute (psychic)', () => {
+  context('scalar columns', () => {
+    it('camelizes the attribute name', () => {
+      expect(parseAttribute('phone_number:string')).toEqual({
+        attributeName: 'phoneNumber',
+        attributeType: 'string',
+        isArray: false,
+        enumValues: undefined,
+      })
+    })
+
+    it('detects arrays', () => {
+      expect(parseAttribute('tags:string[]')).toMatchObject({
+        attributeName: 'tags',
+        attributeType: 'string',
+        isArray: true,
+      })
+    })
+
+    it('coerces uuid-suffix names to uuid type', () => {
+      expect(parseAttribute('some_uuid:string')).toMatchObject({
+        attributeType: 'uuid',
+      })
+    })
+  })
+
+  context('filtered columns', () => {
+    it('returns null for _type columns', () => {
+      expect(parseAttribute('owner_type:string')).toBeNull()
+    })
+
+    it('returns null for _id columns', () => {
+      expect(parseAttribute('owner_id:string')).toBeNull()
+    })
+
+    it('returns null for deletedAt', () => {
+      expect(parseAttribute('deleted_at:datetime')).toBeNull()
+    })
+  })
+
+  context('belongs_to (legacy form)', () => {
+    it('derives attribute name from model last segment', () => {
+      expect(parseAttribute('User:belongs_to')).toEqual({
+        attributeName: 'user',
+        attributeType: 'belongs_to',
+        isArray: false,
+        enumValues: undefined,
+      })
+    })
+
+    it('handles namespaced models', () => {
+      expect(parseAttribute('Music/Score:belongs_to')).toMatchObject({
+        attributeName: 'score',
+        attributeType: 'belongs_to',
+      })
+    })
+
+    it('handles trailing optional', () => {
+      expect(parseAttribute('User:belongs_to:optional')).toMatchObject({
+        attributeName: 'user',
+        attributeType: 'belongs_to',
+      })
+    })
+  })
+
+  context('belongs_to with @alias (new form)', () => {
+    it('uses the camelized alias as the attribute name', () => {
+      expect(parseAttribute('InternalUser@cancelled_by:belongs_to')).toEqual({
+        attributeName: 'cancelledBy',
+        attributeType: 'belongs_to',
+        isArray: false,
+        enumValues: undefined,
+      })
+    })
+
+    it('handles namespaced model with alias', () => {
+      expect(parseAttribute('Messaging/Message@last_inbound_message:belongs_to:optional')).toMatchObject({
+        attributeName: 'lastInboundMessage',
+        attributeType: 'belongs_to',
+      })
+    })
+
+    it('returns null for empty alias after @', () => {
+      expect(parseAttribute('Model@:belongs_to')).toBeNull()
+    })
+
+    it('returns null for empty model before @', () => {
+      expect(parseAttribute('@alias:belongs_to')).toBeNull()
+    })
+  })
+
+  context('enum forms', () => {
+    it('extracts enum values for declare-with-values form', () => {
+      expect(parseAttribute('style:enum:place_styles:fancy,casual')).toMatchObject({
+        attributeName: 'style',
+        attributeType: 'enum',
+        enumValues: 'fancy,casual',
+      })
+    })
+
+    it('leaves enumValues undefined for reuse form', () => {
+      expect(parseAttribute('style:enum:place_styles_enum')).toMatchObject({
+        attributeName: 'style',
+        attributeType: 'enum',
+        enumValues: undefined,
+      })
+    })
+
+    it('does not treat optional as enum values', () => {
+      expect(parseAttribute('style:enum:place_styles:fancy,casual:optional')).toMatchObject({
+        enumValues: 'fancy,casual',
+      })
+    })
+  })
+
+  context('malformed tokens', () => {
+    it('returns null when name is missing', () => {
+      expect(parseAttribute(':string')).toBeNull()
+    })
+
+    it('returns null when type is missing', () => {
+      expect(parseAttribute('email')).toBeNull()
+    })
+  })
+})

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,7 +12,7 @@ import Watcher from '../watcher/Watcher.js'
 
 const INDENT = '                  '
 
-const baseColumnsWithTypesDescription = `space separated snake-case (except for belongs_to model name) properties like this:
+const baseColumnsWithTypesDescription = `space separated snake-case (except for belongs_to model name, which may take an @alias suffix to rename the FK) properties like this:
 ${INDENT}    title:citext subtitle:string body_markdown:text style:enum:post_styles:formal,informal User:belongs_to
 ${INDENT}
 ${INDENT}all properties default to not nullable; null can be allowed by appending ':optional':
@@ -74,7 +74,12 @@ ${INDENT}
 ${INDENT}        use the fully qualified model name (matching its path under src/app/models/):
 ${INDENT}          User:belongs_to                  # creates user_id column + BelongsTo association
 ${INDENT}          Health/Coach:belongs_to           # creates health_coach_id column + BelongsTo association
-${INDENT}          User:belongs_to:optional          # nullable foreign key (for optional associations)`
+${INDENT}          User:belongs_to:optional          # nullable foreign key (for optional associations)
+${INDENT}
+${INDENT}        rename the FK with Model@alias (snake_case alias becomes the column + camelCase property):
+${INDENT}          InternalUser@cancelled_by:belongs_to:optional      # cancelled_by_id column, cancelledBy property
+${INDENT}          Messaging/Message@last_inbound:belongs_to          # last_inbound_id column, lastInbound property
+${INDENT}        Aliasing lets you declare multiple FKs to the same model in one generator call without column collisions.`
 
 export default class PsychicCLI {
   public static provide(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -76,10 +76,13 @@ ${INDENT}          User:belongs_to                  # creates user_id column + B
 ${INDENT}          Health/Coach:belongs_to           # creates health_coach_id column + BelongsTo association
 ${INDENT}          User:belongs_to:optional          # nullable foreign key (for optional associations)
 ${INDENT}
-${INDENT}        rename the FK with Model@alias (snake_case alias becomes the column + camelCase property):
-${INDENT}          InternalUser@cancelled_by:belongs_to:optional      # cancelled_by_id column, cancelledBy property
-${INDENT}          Messaging/Message@last_inbound:belongs_to          # last_inbound_id column, lastInbound property
-${INDENT}        Aliasing lets you declare multiple FKs to the same model in one generator call without column collisions.`
+${INDENT}        rename the association with Model@alias — the snake_case alias drives the FK column name AND the
+${INDENT}        @deco.BelongsTo association name + typed property name on the model:
+${INDENT}          InternalUser@canceled_by:belongs_to:optional       # canceled_by_id column, canceledBy property,
+${INDENT}                                                             #   @deco.BelongsTo('InternalUser', { on: 'canceledById', optional: true })
+${INDENT}          Messaging/Template@template:belongs_to             # template_id column, template property (strips the namespace
+${INDENT}                                                             #   from the property name while keeping the namespaced model reference)
+${INDENT}        Aliasing also lets you declare multiple FKs to the same model in one generator call without column collisions.`
 
 export default class PsychicCLI {
   public static provide(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -77,11 +77,12 @@ ${INDENT}          Health/Coach:belongs_to           # creates health_coach_id c
 ${INDENT}          User:belongs_to:optional          # nullable foreign key (for optional associations)
 ${INDENT}
 ${INDENT}        rename the association with Model@alias — the snake_case alias drives the FK column name AND the
-${INDENT}        @deco.BelongsTo association name + typed property name on the model:
-${INDENT}          InternalUser@canceled_by:belongs_to:optional       # canceled_by_id column, canceledBy property,
+${INDENT}        @deco.BelongsTo association + typed FK property on the generated model:
+${INDENT}          InternalUser@canceled_by:belongs_to:optional       # canceled_by_id column, canceledById property, canceledBy association,
 ${INDENT}                                                             #   @deco.BelongsTo('InternalUser', { on: 'canceledById', optional: true })
-${INDENT}          Messaging/Template@template:belongs_to             # template_id column, template property (strips the namespace
-${INDENT}                                                             #   from the property name while keeping the namespaced model reference)
+${INDENT}          Messaging/Template@template:belongs_to             # template_id column, templateId property, template association
+${INDENT}                                                             #   (strips the namespace from the property/association names while keeping
+${INDENT}                                                             #   the namespaced model reference intact)
 ${INDENT}        Aliasing also lets you declare multiple FKs to the same model in one generator call without column collisions.`
 
 export default class PsychicCLI {

--- a/src/generate/helpers/parseAttribute.ts
+++ b/src/generate/helpers/parseAttribute.ts
@@ -17,18 +17,48 @@ export interface ParsedAttribute {
  * paramSafe column allowlist) share one canonical interpretation of the
  * tokens — and one canonical casing (camelCase) for the resulting attribute
  * name.
+ *
+ * Supports the `Model@alias:belongs_to` shorthand for renaming the FK
+ * association. When `@alias` is present, the camelized alias becomes
+ * `attributeName`; otherwise (legacy form `Model:belongs_to`) the
+ * attribute name is derived from the model's last namespace segment.
+ *
+ * Mirrors Dream's CLI-side `parseAttribute` (kept as a parallel
+ * implementation rather than a shared import so neither package leaks an
+ * internal CLI helper through its public API surface).
  */
 export default function parseAttribute(attribute: string): ParsedAttribute | null {
-  const [rawAttributeName, rawAttributeType, , enumValues] = attribute.split(':')
+  const segments = attribute.split(':')
+  const rawSegmentOne = segments[0]
+  const rawAttributeType = segments[1]
 
-  if (!rawAttributeName || !rawAttributeType) return null
+  if (!rawSegmentOne || !rawAttributeType) return null
+
+  // Extract optional `@alias` from segment-1 (used by the belongs_to FK alias
+  // shorthand, e.g., `InternalUser@cancelled_by:belongs_to`).
+  let rawAttributeName = rawSegmentOne
+  let aliasName: string | undefined
+  const atIndex = rawSegmentOne.indexOf('@')
+  if (atIndex !== -1) {
+    rawAttributeName = rawSegmentOne.slice(0, atIndex)
+    const rawAlias = rawSegmentOne.slice(atIndex + 1)
+    if (!rawAttributeName || !rawAlias) return null
+    aliasName = rawAlias
+  }
+
+  // Pop trailing `optional` keyword from descriptors so it doesn't get
+  // mistaken for enum values or other positional descriptors.
+  const descriptors = segments.slice(2)
+  if (descriptors[descriptors.length - 1] === 'optional') descriptors.pop()
+  const enumValues = descriptors[1]
 
   const sanitizedAttrType = camelize(rawAttributeType)?.toLowerCase()
 
   // Handle belongs_to relationships
   if (sanitizedAttrType === 'belongsto') {
-    // For belongs_to relationships, convert "Ticketing/Ticket" to "ticket"
-    const attributeName = camelize(rawAttributeName.split('/').pop()!)
+    // For belongs_to relationships, prefer the explicit alias when present;
+    // otherwise convert "Ticketing/Ticket" → "ticket".
+    const attributeName = aliasName ? camelize(aliasName) : camelize(rawAttributeName.split('/').pop()!)
     return { attributeName, attributeType: 'belongs_to', isArray: false, enumValues }
   }
 

--- a/src/generate/helpers/parseAttribute.ts
+++ b/src/generate/helpers/parseAttribute.ts
@@ -35,7 +35,7 @@ export default function parseAttribute(attribute: string): ParsedAttribute | nul
   if (!rawSegmentOne || !rawAttributeType) return null
 
   // Extract optional `@alias` from segment-1 (used by the belongs_to FK alias
-  // shorthand, e.g., `InternalUser@cancelled_by:belongs_to`).
+  // shorthand, e.g., `InternalUser@canceled_by:belongs_to`).
   let rawAttributeName = rawSegmentOne
   let aliasName: string | undefined
   const atIndex = rawSegmentOne.indexOf('@')


### PR DESCRIPTION
## Summary

Adds `@alias` support to psychic's `parseAttribute` so the `Model@alias:belongs_to` shorthand introduced in **rvohealth/dream#697** flows correctly through psychic's resource generator (`g:resource`).

- **`@alias` support in `parseAttribute`** (`7f735c8c`) — when `Model@alias:belongs_to` is present, the camelized alias becomes the attribute name; otherwise the legacy "derive from model's last segment" behavior is preserved. Also pops trailing `optional` from descriptors so it can't be mistaken for enum values. 18 specs.
- **Spec lock-in for resource scaffold filtering** (`7aeeb7f4`) — focused spec around `paramSafeColumnNamesFromCliTokens` proving aliased `belongs_to` (e.g., `InternalUser@cancelled_by:belongs_to`) is correctly filtered from the controller's param allowlist just like the legacy form is. 5 specs.

The parser update transparently flows the aliased camelized property name through `generateResourceControllerSpecContent` and `generateControllerContent` — no consumer changes needed.

## Companion PR

Pairs with **rvohealth/dream#697** which lands the dream-side parser, model/migration/factory generator updates, and four other generator cleanups. Both PRs are independent and either can land first, but dream's PR is the larger surface.

## Design note

Psychic's `parseAttribute` mirrors dream's CLI parser as a parallel implementation rather than importing dream's helper. Keeps both packages' CLI parsing internal to their public API surfaces; co-maintained packages accept the drift risk.

## Plan / context

Plan + interview transcript: monorepo's `plans/2026-05-13-generator-cleanup-cluster/PLAN.md`.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm build:test-app`
- [x] `pnpm uspec` — 1219 passed (163 spec files)
- [x] `pnpm fspec` — 3 passed (2 spec files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)