### PR TITLE
Security hardening: supply-chain defaults + Bun/Deno PackageManager support

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,6 +19,24 @@ permissions:
   statuses: none
 
 jobs:
+  check-cooldown-excludes:
+    name: Cooldown exclude allowlist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: minimumReleaseAgeExclude must be @rvoh/* only
+        run: |
+          # SECURITY: the minimumReleaseAge cooldown bypass list must stay @rvoh/*
+          # only (our own packages). Any third-party entry is a permanent
+          # supply-chain bypass and must be rejected — apply urgent patches via a
+          # transient, reverted override instead of a persistent exclude.
+          bad=$(grep -nE '^[[:space:]]*minimumReleaseAgeExclude' .npmrc | grep -vE '=[[:space:]]*@rvoh/' || true)
+          if [ -n "$bad" ]; then
+            echo "::error::Non-@rvoh minimumReleaseAgeExclude entries (cooldown bypass must stay @rvoh/* only):"
+            echo "$bad"
+            exit 1
+          fi
+
   uspec:
     name: Unit tests (Node ${{ matrix.node-version }})
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dist
 typetrace/*
 
 .pnp.*
+plans/

--- a/.npmrc
+++ b/.npmrc
@@ -2,7 +2,7 @@ registry=https://registry.npmjs.org
 @rvoh:registry=https://registry.npmjs.org
 //registry.npmjs.org/:always-auth=true
 
-minimumReleaseAge=1440 # (in minutes, ensuring that all packages must be at least 24 hours old)
+minimumReleaseAge=4320 # 3 days, in minutes (supply-chain cooldown; kept under the CVE-patch SLA so routine patching needs no bypass)
 minimumReleaseAgeExclude[] = @rvoh/dream
 minimumReleaseAgeExclude[] = @rvoh/dream-spec-helpers
 minimumReleaseAgeExclude[] = @rvoh/psychic-spec-helpers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.0
+
+- `PackageManager` — used by the CLI to spawn package-manager subprocesses during `sync` (run by `db:migrate`/`db:reset`), generators, and setup commands — now emits correct commands for `bun` and `deno` alongside pnpm/yarn/npm: `run` → `bun run <cmd>` / `deno task <cmd>`; `exec` → `bunx` / `deno run -A npm:<bin>`; `add` → `bun add` / `deno add` (with `npm:` specifier prefixing). The prior `<pm> <cmd>` default fit pnpm/yarn but produced e.g. `deno post-sync`, which Deno reads as a file path (→ "Module not found"), breaking `sync` under Deno. Enables `@rvoh/create-psychic` to scaffold Bun/Deno apps. Requires `@rvoh/dream` ≥ 2.12.0 in the consuming app (its package-manager enum must list bun/deno).
+
 ## 3.4.2
 
 Fixes a graceful-shutdown hang in `PsychicServer.stop()`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,3 +7,16 @@ We currently support the latest version of Psychic v2. Our goal is to avoid brea
 ## Reporting a Vulnerability
 
 To report a vulnerability, please contact us at [psychic-security@rvohealth.com](mailto:psychic-security@rvohealth.com). Once the vulnerability is verified, a patch will be provided. Once the patch is provided, a new version will be published closing the vulnerability. Private contact will resume between the reporter and the code maintainers until the vulnerability is resolved.
+
+## Supply-chain hardening
+
+This package is developed and published with defenses against install-time supply-chain attacks (the Shai-Hulud class of npm worm, which runs from a dependency's `postinstall` and/or publishes a compromised version for maintainers to install before it is noticed):
+
+- **Dependency build scripts are blocked by default.** pnpm 10+ does not run dependency lifecycle scripts; `pnpm-workspace.yaml` keeps a deliberately minimal `allowBuilds` allowlist (only the few packages that genuinely need to build). Every entry re-opens script execution, so additions require a clear reason.
+- **Release-age cooldown.** `.npmrc` sets `minimumReleaseAge=4320` (3 days), so freshly-published dependency versions — the window in which most worm-injected releases are caught and unpublished — are not installed. Three days stays under the critical-CVE patch SLA, so routine patching never needs a bypass.
+- **The cooldown exclude list is `@rvoh/*`-only, enforced in CI.** Only our own first-party packages are exempt from the cooldown. A CI check (`check-cooldown-excludes`) fails the build if any non-`@rvoh/*` entry is added to `minimumReleaseAgeExclude`, so a permanent third-party bypass cannot be introduced silently. Apply an urgent third-party patch with a transient, reverted override instead.
+- **Registry pinning.** `.npmrc` pins the npm registry so installs cannot be redirected to a malicious mirror.
+
+## Publishing posture
+
+Releases are published **manually, from a maintainer's machine, gated by npm two-factor authentication** — there is no CI/token-based publish. This is a deliberate anti-worm choice: it keeps publishing credentials off CI (a prime target for self-propagating worms that harvest CI/CD secrets) and behind a human MFA prompt. npm provenance / OIDC publishing was evaluated and **deferred** for that reason — adopting it would relocate publishing into automated CI and trade the human MFA gate for a long-lived automated trust relationship. It remains a deliberate future decision, not a default.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.4.2",
+  "version": "3.5.0",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,11 @@ overrides:
   diff: '>=8.0.3'
   path-to-regexp: '>=8.4.0'
 
+# SECURITY — allowBuilds is a supply-chain allowlist. pnpm 10+ blocks ALL
+# dependency lifecycle scripts (postinstall, etc.) by default; that default is
+# the primary defense against Shai-Hulud-class npm worms. Only packages listed
+# below (= true) may run install/build scripts. Keep this MINIMAL — every entry
+# re-opens script execution for that package, so add one only with clear cause.
 allowBuilds:
   esbuild: true
   puppeteer: true

--- a/spec/unit/cli/helpers/PackageManager.spec.ts
+++ b/spec/unit/cli/helpers/PackageManager.spec.ts
@@ -1,0 +1,123 @@
+import PackageManager from '../../../../src/cli/helpers/PackageManager.js'
+import PsychicApp from '../../../../src/psychic-app/index.js'
+
+// PackageManager turns a logical command (`run`/`add`/`exec`) into the concrete
+// argv for whichever package manager the app is configured with. pnpm/yarn share
+// the permissive `<pm> <cmd>` form; npm, bun, and deno each need a distinct shape
+// (verified against bun 1.3 / deno 2.8: `bun <script>` is file-exec so `run` is
+// required, and deno has no script shorthand at all — `deno task` resolves a
+// package.json script and forwards trailing args).
+describe('PackageManager', () => {
+  function usePackageManager(packageManager: string) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+    vi.spyOn(PsychicApp, 'getOrFail').mockReturnValue({ packageManager } as any)
+  }
+
+  describe('.run', () => {
+    it('pnpm', () => {
+      usePackageManager('pnpm')
+      expect(PackageManager.run('psy', ['sync'])).toEqual({ command: 'pnpm', args: ['psy', 'sync'] })
+    })
+
+    it('yarn', () => {
+      usePackageManager('yarn')
+      expect(PackageManager.run('psy', ['sync'])).toEqual({ command: 'yarn', args: ['psy', 'sync'] })
+    })
+
+    it('npm separates script args with --', () => {
+      usePackageManager('npm')
+      expect(PackageManager.run('psy', ['sync'])).toEqual({
+        command: 'npm',
+        args: ['run', 'psy', '--', 'sync'],
+      })
+      expect(PackageManager.run('psy')).toEqual({ command: 'npm', args: ['run', 'psy'] })
+    })
+
+    it('bun requires `run` (bare `bun <script>` is file execution)', () => {
+      usePackageManager('bun')
+      expect(PackageManager.run('psy', ['sync'])).toEqual({ command: 'bun', args: ['run', 'psy', 'sync'] })
+    })
+
+    it('deno uses `deno task` (no `<pm> <script>` shorthand exists)', () => {
+      usePackageManager('deno')
+      expect(PackageManager.run('psy', ['sync'])).toEqual({ command: 'deno', args: ['task', 'psy', 'sync'] })
+    })
+  })
+
+  describe('.add', () => {
+    it('pnpm / yarn', () => {
+      usePackageManager('pnpm')
+      expect(PackageManager.add('lodash')).toEqual({ command: 'pnpm', args: ['add', 'lodash'] })
+      expect(PackageManager.add('lodash', { dev: true })).toEqual({
+        command: 'pnpm',
+        args: ['add', '-D', 'lodash'],
+      })
+    })
+
+    it('npm', () => {
+      usePackageManager('npm')
+      expect(PackageManager.add(['a', 'b'])).toEqual({ command: 'npm', args: ['install', 'a', 'b'] })
+      expect(PackageManager.add('a', { dev: true })).toEqual({
+        command: 'npm',
+        args: ['install', '--save-dev', 'a'],
+      })
+    })
+
+    it('bun', () => {
+      usePackageManager('bun')
+      expect(PackageManager.add('lodash')).toEqual({ command: 'bun', args: ['add', 'lodash'] })
+      expect(PackageManager.add('lodash', { dev: true })).toEqual({
+        command: 'bun',
+        args: ['add', '--dev', 'lodash'],
+      })
+    })
+
+    it('deno prefixes bare names with npm: and preserves existing specifiers', () => {
+      usePackageManager('deno')
+      expect(PackageManager.add(['lodash', 'npm:zod', 'jsr:@std/assert'])).toEqual({
+        command: 'deno',
+        args: ['add', 'npm:lodash', 'npm:zod', 'jsr:@std/assert'],
+      })
+      expect(PackageManager.add('lodash', { dev: true })).toEqual({
+        command: 'deno',
+        args: ['add', '--dev', 'npm:lodash'],
+      })
+    })
+  })
+
+  describe('.exec', () => {
+    it('pnpm', () => {
+      usePackageManager('pnpm')
+      expect(PackageManager.exec('oasdiff', ['diff'])).toEqual({
+        command: 'pnpm',
+        args: ['exec', 'oasdiff', 'diff'],
+      })
+    })
+
+    it('yarn', () => {
+      usePackageManager('yarn')
+      expect(PackageManager.exec('oasdiff', ['diff'])).toEqual({ command: 'yarn', args: ['oasdiff', 'diff'] })
+    })
+
+    it('npm', () => {
+      usePackageManager('npm')
+      expect(PackageManager.exec('oasdiff', ['diff'])).toEqual({
+        command: 'npm',
+        args: ['exec', '--', 'oasdiff', 'diff'],
+      })
+    })
+
+    it('bun uses bunx', () => {
+      usePackageManager('bun')
+      expect(PackageManager.exec('oasdiff', ['diff'])).toEqual({ command: 'bunx', args: ['oasdiff', 'diff'] })
+    })
+
+    it('deno runs an npm: specifier with -A', () => {
+      usePackageManager('deno')
+      expect(PackageManager.exec('oasdiff', ['diff'])).toEqual({
+        command: 'deno',
+        args: ['run', '-A', 'npm:oasdiff', 'diff'],
+      })
+    })
+  })
+})

--- a/src/cli/helpers/PackageManager.ts
+++ b/src/cli/helpers/PackageManager.ts
@@ -5,8 +5,16 @@ export interface PackageManagerCommand {
   args: string[]
 }
 
+// Runtimes this class knows how to drive. `@rvoh/dream`'s published
+// DreamAppAllowedPackageManagersEnum gained 'bun'/'deno' in the same effort as
+// these command shapes; widening here lets PackageManager compile against an
+// older published dream (whose enum is still pnpm/yarn/npm). It's a safe upcast
+// of a value dream validates at app init, and becomes a no-op once the consuming
+// dream lists bun/deno.
+type SupportedPackageManager = 'pnpm' | 'yarn' | 'npm' | 'bun' | 'deno'
+
 export default class PackageManager {
-  public static get packageManager() {
+  public static get packageManager(): SupportedPackageManager {
     return PsychicApp.getOrFail().packageManager
   }
 

--- a/src/cli/helpers/PackageManager.ts
+++ b/src/cli/helpers/PackageManager.ts
@@ -22,6 +22,11 @@ export default class PackageManager {
       switch (this.packageManager) {
         case 'npm':
           return { command: 'npm', args: ['install', '--save-dev', ...list] }
+        case 'bun':
+          return { command: 'bun', args: ['add', '--dev', ...list] }
+        case 'deno':
+          // Deno needs an explicit registry prefix to add npm packages.
+          return { command: 'deno', args: ['add', '--dev', ...denoSpecifiers(list)] }
         default:
           return { command: this.packageManager, args: ['add', '-D', ...list] }
       }
@@ -29,6 +34,10 @@ export default class PackageManager {
       switch (this.packageManager) {
         case 'npm':
           return { command: 'npm', args: ['install', ...list] }
+        case 'bun':
+          return { command: 'bun', args: ['add', ...list] }
+        case 'deno':
+          return { command: 'deno', args: ['add', ...denoSpecifiers(list)] }
         default:
           return { command: this.packageManager, args: ['add', ...list] }
       }
@@ -43,6 +52,14 @@ export default class PackageManager {
           command: 'npm',
           args: args.length ? ['run', cmd, '--', ...args] : ['run', cmd],
         }
+      case 'bun':
+        // `bun <script>` is treated as file execution; `bun run` is required to
+        // resolve a package.json script. Bun forwards trailing args directly.
+        return { command: 'bun', args: ['run', cmd, ...args] }
+      case 'deno':
+        // Deno has no `<pm> <script>` shorthand; `deno task` resolves a
+        // package.json script (or deno.json task) and forwards trailing args.
+        return { command: 'deno', args: ['task', cmd, ...args] }
       default:
         return { command: this.packageManager, args: [cmd, ...args] }
     }
@@ -54,8 +71,25 @@ export default class PackageManager {
         return { command: 'npm', args: ['exec', '--', cmd, ...args] }
       case 'yarn':
         return { command: 'yarn', args: [cmd, ...args] }
+      case 'bun':
+        return { command: 'bunx', args: [cmd, ...args] }
+      case 'deno':
+        // `deno run` against an npm: specifier is Deno's equivalent of npx;
+        // -A grants the permissions the executed tool needs.
+        return { command: 'deno', args: ['run', '-A', denoSpecifier(cmd), ...args] }
       default:
         return { command: this.packageManager, args: ['exec', cmd, ...args] }
     }
   }
+}
+
+// Deno requires npm/jsr packages to carry an explicit registry prefix
+// (`npm:lodash`); bare names are treated as local/JSR specifiers. Leave any
+// already-prefixed specifier untouched.
+function denoSpecifier(pkg: string): string {
+  return /^(npm|jsr):/.test(pkg) ? pkg : `npm:${pkg}`
+}
+
+function denoSpecifiers(list: string[]): string[] {
+  return list.map(denoSpecifier)
 }


### PR DESCRIPTION
Part of the cross-repo **Psychic ecosystem security hardening** effort — the `psychic` slice. Siblings: `dream` (#704), `psychic-workers`, `psychic-websockets`. `create-psychic` follows once its runtime work is complete.

## What's here

**Supply-chain hardening (items 1–2, 6)**
- Document the `allowBuilds` build-script allowlist rationale; gitignore the local `plans/` dir.
- Raise npm release-age cooldown to 3 days + CI invariant restricting cooldown-bypass to `@rvoh/*`.
- `SECURITY.md`: supply-chain posture + local+MFA publishing rationale.

**Bun/Deno PackageManager support (item 11)**
- `PackageManager.run/add/exec` get explicit `bun` and `deno` shapes (verified against bun 1.3 / deno 2.8): `bun run` / `bunx` / `bun add`; `deno task` / `deno run -A npm:` / `deno add` with `npm:` prefixing. Previously the `<pm> <cmd>` default fit pnpm/yarn but produced e.g. `deno post-sync` → Deno reads it as a file path → *Module not found*, breaking `sync` (run by `db:migrate`).
- New unit spec locks the argv for all five package managers (14 cases, green under vitest).

## ⚠️ Stacked on dream #704 — do not merge first
`PsychicApp.packageManager` is typed against `@rvoh/dream`'s `DreamAppAllowedPackageManagersEnumValues`. The `bun`/`deno` cases only type-check once dream #704 is **published** and this repo's `@rvoh/dream` dep is bumped to it. Until then `build:test-app` (and CI build) reports `TS2678` for the new cases. The runtime logic is verified by the unit spec.

## Verification
`pnpm lint` clean. `pnpm uspec`: 1229 passed (the 2 `server/hooks` failures are local `EADDRINUSE:7777` from another dev server on this machine — clean CI binds an open port). `pnpm build:test-app`: green except the dream-publish-gated `TS2678` above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)