### PR TITLE
Scope generated internal-namespace resources to current internal user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.0
+
+- `g:resource` controllers generated in the `internal` namespace now scope queries to the authenticated internal user the same way default-namespace controllers scope to the current user — `this.currentInternalUser.associationQuery('posts')` / `this.currentInternalUser.createAssociation('posts', …)` — instead of reaching every record in the system via direct model access. Previously the `internal` namespace was treated identically to `admin`, lifting all owner scoping; that meant a generated internal resource defaulted to letting any authenticated internal user read and mutate any record, an unsafe default for a scaffold. The `admin` namespace is unchanged (still unscoped by default), and supplying `--owning-model` still scopes to that model in either namespace. The generated resource spec gains the matching "created by another InternalUser" omission/not-found/not-updated/not-deleted contexts. Generated scaffolds are emitted commented-out, so this only affects newly generated code — no runtime behavior in existing apps changes.
+
 ## 3.6.0
 
 - Migrate the JSON/body middleware from the legacy `koa-bodyparser` to the officially-maintained `@koa/bodyparser` (`^6.1.0`), keeping psychic current with the koa org's supported packages. `@koa/bodyparser` ships its own types, so the `@types/koa-bodyparser` peer/dev dependency is dropped. The unused `@types/koa-etag` peer/dev dependency is also removed (psychic imports `@koa/etag`, which self-types; `koa-etag` was never imported).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/spec/unit/generate/helpers/generateControllerContent.spec.ts
+++ b/spec/unit/generate/helpers/generateControllerContent.spec.ts
@@ -704,7 +704,7 @@ export default class AdminArticlesController extends AdminAuthedController {
 
     context('in the Internal namespace', () => {
       it(
-        'loads/creates/updates/deletes resources without an owning model ' +
+        'loads/creates/updates/deletes resources scoped to the current internal user ' +
           'and sets the serializerKey to internal serializers',
         () => {
           const res = generateControllerContent({
@@ -739,7 +739,7 @@ export default class InternalArticlesController extends InternalAuthedController
     fastJsonStringify: true,
   })
   public async index() {
-    // const articles = await Article
+    // const articles = await this.currentInternalUser.associationQuery('articles')
     //   .preloadFor('internalSummary')
     //   .cursorPaginate({ cursor: this.castParam('cursor', 'string', { allowNull: true }) })
     // this.ok(articles)
@@ -768,7 +768,7 @@ export default class InternalArticlesController extends InternalAuthedController
     },
   })
   public async create() {
-    // let article = await Article.create(this.extractParams(Article, paramSafeColumns))
+    // let article = await this.currentInternalUser.createAssociation('articles', this.extractParams(Article, paramSafeColumns))
     // if (article.isPersisted) article = await article.loadFor('internal').execute()
     // this.created(article)
   }
@@ -812,7 +812,7 @@ export default class InternalArticlesController extends InternalAuthedController
   }
 
   private async article() {
-    // return await Article
+    // return await this.currentInternalUser.associationQuery('articles')
     //   .preloadFor('internal')
     //   .findOrFail(this.castParam('id', 'string'))
   }

--- a/spec/unit/generate/helpers/generateResourceControllerSpecContent.spec.ts
+++ b/spec/unit/generate/helpers/generateResourceControllerSpecContent.spec.ts
@@ -1838,7 +1838,7 @@ describe('Admin/ArticlesController', () => {
   })
 
   context('an Internal controller', () => {
-    it("replaces authenticates with the InternalUser, but created resources don't belong to the InternalUser", () => {
+    it('authenticates with the InternalUser and scopes resources to that InternalUser', () => {
       const res = generateResourceControllerSpecContent({
         fullyQualifiedControllerName: 'Internal/ArticlesController',
         route: 'internal/articles',
@@ -1871,7 +1871,7 @@ describe('Internal/ArticlesController', () => {
     }
 
     it('returns the index of Articles', async () => {
-      const article = await createArticle()
+      const article = await createArticle({ internalUser })
 
       const { body } = await index(200)
 
@@ -1880,6 +1880,16 @@ describe('Internal/ArticlesController', () => {
           id: article.id,
         }),
       ])
+    })
+
+    context('Articles created by another InternalUser', () => {
+      it('are omitted', async () => {
+        await createArticle()
+
+        const { body } = await index(200)
+
+        expect(body.results).toEqual([])
+      })
     })
   })
 
@@ -1891,7 +1901,7 @@ describe('Internal/ArticlesController', () => {
     }
 
     it('returns the specified Article', async () => {
-      const article = await createArticle()
+      const article = await createArticle({ internalUser })
 
       const { body } = await show(article, 200)
 
@@ -1901,6 +1911,14 @@ describe('Internal/ArticlesController', () => {
           body: article.body,
         }),
       )
+    })
+
+    context('Article created by another InternalUser', () => {
+      it('is not found', async () => {
+        const otherInternalUserArticle = await createArticle()
+
+        await show(otherInternalUserArticle, 404)
+      })
     })
   })
 
@@ -1914,12 +1932,12 @@ describe('Internal/ArticlesController', () => {
       })
     }
 
-    it('creates a Article', async () => {
+    it('creates a Article for this InternalUser', async () => {
       const { body } = await create({
         body: 'The Article body',
       }, 201)
 
-      const article = await Article.firstOrFail()
+      const article = await internalUser.associationQuery('articles').firstOrFail()
       expect(article.body).toEqual('The Article body')
 
       expect(body).toEqual(
@@ -1944,7 +1962,7 @@ describe('Internal/ArticlesController', () => {
     }
 
     it('updates the Article', async () => {
-      const article = await createArticle()
+      const article = await createArticle({ internalUser })
 
       await update(article, {
         body: 'Updated Article body',
@@ -1952,6 +1970,20 @@ describe('Internal/ArticlesController', () => {
 
       await article.reload()
       expect(article.body).toEqual('Updated Article body')
+    })
+
+    context('a Article created by another InternalUser', () => {
+      it('is not updated', async () => {
+        const article = await createArticle()
+        const originalBody = article.body
+
+        await update(article, {
+          body: 'Updated Article body',
+        }, 404)
+
+        await article.reload()
+        expect(article.body).toEqual(originalBody)
+      })
     })
   })
 
@@ -1963,11 +1995,21 @@ describe('Internal/ArticlesController', () => {
     }
 
     it('deletes the Article', async () => {
-      const article = await createArticle()
+      const article = await createArticle({ internalUser })
 
       await destroy(article, 204)
 
       expect(await Article.find(article.id)).toBeNull()
+    })
+
+    context('a Article created by another InternalUser', () => {
+      it('is not deleted', async () => {
+        const article = await createArticle()
+
+        await destroy(article, 404)
+
+        expect(await Article.find(article.id)).toMatchDreamModel(article)
+      })
     })
   })
 })

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -164,8 +164,9 @@ ${INDENT}  pnpm psy g:sti-child --model-name=Condo Rental/Condo extends Rental`,
         '--owning-model <modelName>',
         `The model class that owns this resource. The generated controller will use \`associationQuery\` and \`createAssociation\` on the owning model to scope queries and create records.
 ${INDENT}
-${INDENT}Defaults to \`this.currentUser\` for non-admin/internal routes (e.g., \`this.currentUser.associationQuery('posts').findOrFail(this.castParam('id', 'uuid'))\`).
-${INDENT}Defaults to \`null\` for admin/internal namespaced controllers (e.g., \`Post.findOrFail(this.castParam('id', 'uuid'))\`).
+${INDENT}Defaults to \`this.currentUser\` for non-admin routes (e.g., \`this.currentUser.associationQuery('posts').findOrFail(this.castParam('id', 'uuid'))\`).
+${INDENT}Defaults to \`this.currentInternalUser\` for internal namespaced controllers (e.g., \`this.currentInternalUser.associationQuery('posts').findOrFail(this.castParam('id', 'uuid'))\`).
+${INDENT}Defaults to \`null\` for admin namespaced controllers (e.g., \`Post.findOrFail(this.castParam('id', 'uuid'))\`).
 ${INDENT}Supplying an owning-modle changes the the generated code in the controller to be relative to the owning model.
 ${INDENT}
 ${INDENT}Example:
@@ -200,7 +201,7 @@ ${INDENT}  # model is named GroupDanceLesson instead of LessonDanceGroup`,
         '<path>',
         `The URL path for this resource's routes, relative to the root domain. Use \`\\{\\}\` as a placeholder for a parent resource's ID parameter when nesting.
 ${INDENT}
-${INDENT}The path determines the controller namespace hierarchy. Paths that begin with "admin" and "internal" remove the \`currentUser\` scoping of queries (\`--owning-model\` may be provided to apply query scoping). Each segment maps to a directory level in the controllers folder.
+${INDENT}The path determines the controller namespace hierarchy. Paths that begin with "internal" scope queries to \`this.currentInternalUser\` instead of \`this.currentUser\`. Paths that begin with "admin" remove owner scoping of queries entirely (\`--owning-model\` may be provided to apply query scoping). Each segment maps to a directory level in the controllers folder.
 ${INDENT}
 ${INDENT}Examples:
 ${INDENT}  v1/posts                          # /v1/posts, /v1/posts/:id

--- a/src/generate/helpers/generateControllerContent.ts
+++ b/src/generate/helpers/generateControllerContent.ts
@@ -44,8 +44,10 @@ export default function generateControllerContent({
     fullyQualifiedControllerName,
   )
 
-  // Determine user model variables
-  const actualOwningModel = owningModel || 'User'
+  // Determine user model variables. Internal-namespaced controllers scope to
+  // the current internal user the same way default controllers scope to the
+  // current user; only the Admin namespace bypasses owner scoping entirely.
+  const actualOwningModel = owningModel || (forInternal ? 'InternalUser' : 'User')
   const owningModelClassName = DreamApp.system.globalClassNameFromFullyQualifiedModelName(actualOwningModel)
   const owningModelProperty = `current${owningModelClassName}`
 
@@ -69,7 +71,7 @@ export default function generateControllerContent({
     serializerKey: 'internal',`
       : ''
 
-  const useDirectModelAccess = (forAdmin || forInternal) && !owningModel
+  const useDirectModelAccess = forAdmin && !owningModel
   const loadQueryBase: string = useDirectModelAccess
     ? (modelClassName ?? 'no-class-name')
     : `this.${owningModelProperty}.associationQuery('${pluralizedModelAttributeName}')`

--- a/src/generate/helpers/generateResourceControllerSpecContent.ts
+++ b/src/generate/helpers/generateResourceControllerSpecContent.ts
@@ -101,7 +101,7 @@ function createModelConfiguration(options: GenerateSpecOptions): ModelConfigurat
     ? camelize(DreamApp.system.standardizeFullyQualifiedModelName(options.owningModel).split('/').pop()!)
     : userVariableName
 
-  const useDirectModelAccess = (options.forAdmin || options.forInternal) && !options.owningModel
+  const useDirectModelAccess = options.forAdmin && !options.owningModel
   const simpleCreationCommand = `const ${modelVariableName} = await create${modelClassName}(${useDirectModelAccess ? '' : `{ ${owningModelVariableName} }`})`
 
   return {


### PR DESCRIPTION
## Summary

Generated `internal` namespace resources were treated identically to `admin`: they defaulted to direct, unscoped model access, so a freshly generated internal resource let any authenticated internal user read and mutate **any** record in the system. That's an unsafe default for a scaffold.

This changes the `internal` namespace to scope queries to the authenticated internal user the same way default-namespace controllers scope to `this.currentUser`:

- `this.currentInternalUser.associationQuery('posts')` for reads
- `this.currentInternalUser.createAssociation('posts', …)` for creates

The `admin` namespace is unchanged (still unscoped by default), and `--owning-model` still scopes to that model in either namespace.

## Changes

- `generateControllerContent.ts` — internal namespace now defaults its owning model to `InternalUser`; `useDirectModelAccess` is now `admin`-only.
- `generateResourceControllerSpecContent.ts` — internal resource specs are now scoped, gaining the "created by another InternalUser" omission / not-found / not-updated / not-deleted contexts.
- `src/cli/index.ts` — `g:resource` help text updated to describe internal vs admin scoping accurately.
- Updated generator unit specs; bumped to 3.7.0 with a changelog entry.

## Notes

Generated scaffolds are emitted commented-out, so this only affects newly generated code — no runtime behavior in existing apps changes.

## Test plan

- `pnpm uspec spec/unit/generate/` — 100 passing
- `pnpm build:test-app` — clean
- `pnpm lint` / `pnpm format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)