### PR TITLE
Rename OpenAPI request body allowlist to params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.7.1
+## 3.8.0
 
 - `Params.for` and `PsychicController#extractParams` now cast and validate Dream virtual columns, including `@Encrypted` fields, from their declared OpenAPI metadata instead of passing them through unchecked. This makes virtual param handling match concrete Dream columns: `@Virtual(['string', 'null'])` and nullable `@Encrypted` params reject non-strings while allowing `null`, and virtual array shorthands such as `string[]` are cast through the same array path used for database-backed array columns.
 - `@OpenAPI` model-derived `requestBody` allowlists now use `params` as the canonical key (`requestBody: { params: paramSafeColumns }`) to match the explicit `extractParams(Model, paramSafeColumns)` flow. The previous `only` key still works as a deprecated compatibility alias, including inside nested `{ for: Model }` request-body shorthand and `OpenAPI.forDream(Model, ...)`, but newly generated `create` / `update` scaffolds emit `params` so the documented request shape and runtime extraction call both read as explicit request params.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.7.1
 
 - `Params.for` and `PsychicController#extractParams` now cast and validate Dream virtual columns, including `@Encrypted` fields, from their declared OpenAPI metadata instead of passing them through unchecked. This makes virtual param handling match concrete Dream columns: `@Virtual(['string', 'null'])` and nullable `@Encrypted` params reject non-strings while allowing `null`, and virtual array shorthands such as `string[]` are cast through the same array path used for database-backed array columns.
+- `@OpenAPI` model-derived `requestBody` allowlists now use `params` as the canonical key (`requestBody: { params: paramSafeColumns }`) to match the explicit `extractParams(Model, paramSafeColumns)` flow. The previous `only` key still works as a deprecated compatibility alias, including inside nested `{ for: Model }` request-body shorthand and `OpenAPI.forDream(Model, ...)`, but newly generated `create` / `update` scaffolds emit `params` so the documented request shape and runtime extraction call both read as explicit request params.
 
 ## 3.7.0
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.7.1",
+  "version": "3.8.0",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/spec/unit/generate/helpers/generateControllerContent.spec.ts
+++ b/spec/unit/generate/helpers/generateControllerContent.spec.ts
@@ -59,7 +59,7 @@ export default class PostsController extends AuthedController {
     description: 'Create a Post',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async create() {
@@ -74,7 +74,7 @@ export default class PostsController extends AuthedController {
     description: 'Update a Post',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async update() {
@@ -157,7 +157,7 @@ export default class HostingAgreementController extends AuthedController {
     description: 'Create a HostingAgreement',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async create() {
@@ -172,7 +172,7 @@ export default class HostingAgreementController extends AuthedController {
     description: 'Update a HostingAgreement',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async update() {
@@ -261,7 +261,7 @@ export default class ApiV1HealthPostsController extends AuthedController {
     description: 'Create a HealthPost',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async create() {
@@ -276,7 +276,7 @@ export default class ApiV1HealthPostsController extends AuthedController {
     description: 'Update a HealthPost',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async update() {
@@ -418,7 +418,7 @@ export default class PostsController extends AuthedController {
     description: 'Create a Post',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async create() {
@@ -433,7 +433,7 @@ export default class PostsController extends AuthedController {
     description: 'Update a Post',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async update() {
@@ -537,7 +537,7 @@ export default class AdminArticlesController extends AdminAuthedController {
     serializerKey: 'admin',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async create() {
@@ -552,7 +552,7 @@ export default class AdminArticlesController extends AdminAuthedController {
     description: 'Update a Article',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async update() {
@@ -654,7 +654,7 @@ export default class AdminArticlesController extends AdminAuthedController {
     serializerKey: 'admin',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async create() {
@@ -669,7 +669,7 @@ export default class AdminArticlesController extends AdminAuthedController {
     description: 'Update a Article',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async update() {
@@ -764,7 +764,7 @@ export default class InternalArticlesController extends InternalAuthedController
     serializerKey: 'internal',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async create() {
@@ -779,7 +779,7 @@ export default class InternalArticlesController extends InternalAuthedController
     description: 'Update a Article',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async update() {
@@ -882,7 +882,7 @@ export default class InternalArticlesController extends InternalAuthedController
     serializerKey: 'internal',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async create() {
@@ -897,7 +897,7 @@ export default class InternalArticlesController extends InternalAuthedController
     description: 'Update a Article',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async update() {

--- a/spec/unit/openapi-renderer/endpoint/toPathObject.spec.ts
+++ b/spec/unit/openapi-renderer/endpoint/toPathObject.spec.ts
@@ -1263,8 +1263,30 @@ describe('OpenapiEndpointRenderer', () => {
           })
         })
 
-        context('with only provided', () => {
+        context('with params provided', () => {
           it('excludes params to the list provided', () => {
+            const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
+              requestBody: { params: ['email'] },
+            })
+
+            const response = renderer.toPathObject(routes, defaultToPathObjectOpts()).openapi
+            expect(response['/users']!.post.requestBody).toEqual({
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      email: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            })
+          })
+
+          it('supports only as a deprecated alias', () => {
             const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
               requestBody: { only: ['email'] },
             })
@@ -1290,7 +1312,7 @@ describe('OpenapiEndpointRenderer', () => {
         context('with including provided', () => {
           it('includes params provided by the list', () => {
             const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
-              requestBody: { only: ['email'], including: ['id'] },
+              requestBody: { params: ['email'], including: ['id'] },
             })
 
             const response = renderer.toPathObject(routes, defaultToPathObjectOpts()).openapi
@@ -1343,7 +1365,7 @@ describe('OpenapiEndpointRenderer', () => {
           context('with including provided with blank only', () => {
             it('includes params provided by the including list exclusively', () => {
               const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
-                requestBody: { including: ['id'], only: [] },
+                requestBody: { including: ['id'], params: [] },
               })
 
               const response = renderer.toPathObject(routes, defaultToPathObjectOpts()).openapi
@@ -1401,7 +1423,7 @@ describe('OpenapiEndpointRenderer', () => {
             it('combines whatever is provided to combining along with the only/including args', () => {
               const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
                 requestBody: {
-                  only: ['email'],
+                  params: ['email'],
                   including: ['id'],
                   combining: {
                     name: 'string',
@@ -1436,10 +1458,10 @@ describe('OpenapiEndpointRenderer', () => {
         })
       })
 
-      context('requestBody leverages only opt', () => {
-        it('only renders attributes specified in only array', () => {
+      context('requestBody leverages params opt', () => {
+        it('only renders attributes specified in params array', () => {
           const renderer = new OpenapiEndpointRenderer(Pet, ApiPetsController, 'create', {
-            requestBody: { only: ['species', 'name'] },
+            requestBody: { params: ['species', 'name'] },
           })
 
           const response = renderer.toPathObject(routes, defaultToPathObjectOpts()).openapi
@@ -1465,7 +1487,7 @@ describe('OpenapiEndpointRenderer', () => {
           context('requestBody leverages required opt', () => {
             it('renders the required options in the required field', () => {
               const renderer = new OpenapiEndpointRenderer(Pet, ApiPetsController, 'create', {
-                requestBody: { only: ['species', 'name'], required: ['species'] },
+                requestBody: { params: ['species', 'name'], required: ['species'] },
               })
 
               const response = renderer.toPathObject(routes, defaultToPathObjectOpts()).openapi
@@ -1492,7 +1514,7 @@ describe('OpenapiEndpointRenderer', () => {
           context('requestBody leverages for opt', () => {
             it('uses the model provided in the for option to determine request body shape', () => {
               const renderer = new OpenapiEndpointRenderer(Pet, ApiPetsController, 'create', {
-                requestBody: { for: User, only: ['email'], required: ['id'], including: ['id'] },
+                requestBody: { for: User, params: ['email'], required: ['id'], including: ['id'] },
               })
 
               const response = renderer.toPathObject(routes, defaultToPathObjectOpts()).openapi
@@ -1515,7 +1537,7 @@ describe('OpenapiEndpointRenderer', () => {
             context('requestBody leverages for opt with virtual attributes', () => {
               it('includes virtual attributes in the request body', () => {
                 const renderer = new OpenapiEndpointRenderer(Pet, ApiPetsController, 'create', {
-                  requestBody: { for: User, only: ['openapiVirtualSpecTest'] },
+                  requestBody: { for: User, params: ['openapiVirtualSpecTest'] },
                 })
 
                 const response = renderer.toPathObject(routes, defaultToPathObjectOpts()).openapi
@@ -2013,7 +2035,7 @@ describe('OpenapiEndpointRenderer', () => {
           it("expands OpenAPI.forDream(Model) into an object schema using that model's param-safe columns", () => {
             const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
               requestBody: {
-                only: ['email'],
+                params: ['email'],
                 combining: {
                   pets: {
                     type: 'array',
@@ -2041,7 +2063,7 @@ describe('OpenapiEndpointRenderer', () => {
           it('attaches required on the nested model schema, not on the outer array', () => {
             const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
               requestBody: {
-                only: ['email'],
+                params: ['email'],
                 combining: {
                   pets: {
                     type: 'array',
@@ -2066,7 +2088,7 @@ describe('OpenapiEndpointRenderer', () => {
           it('adds the included column to the nested model schema', () => {
             const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
               requestBody: {
-                only: ['email'],
+                params: ['email'],
                 combining: {
                   pets: {
                     type: 'array',
@@ -2088,11 +2110,11 @@ describe('OpenapiEndpointRenderer', () => {
           it('narrows the nested model schema to just the listed columns', () => {
             const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
               requestBody: {
-                only: ['email'],
+                params: ['email'],
                 combining: {
                   pets: {
                     type: 'array',
-                    items: OpenAPI.forDream(Pet, { only: ['name'] }),
+                    items: OpenAPI.forDream(Pet, { params: ['name'] }),
                   },
                 },
               },
@@ -2114,14 +2136,14 @@ describe('OpenapiEndpointRenderer', () => {
           it('expands an OpenAPI.forDream nested inside another forDream call combining', () => {
             const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
               requestBody: {
-                only: ['email'],
+                params: ['email'],
                 combining: {
                   pets: {
                     type: 'array',
                     items: OpenAPI.forDream(Pet, {
-                      only: ['name'],
+                      params: ['name'],
                       combining: {
-                        owner: OpenAPI.forDream(User, { only: ['email'] }),
+                        owner: OpenAPI.forDream(User, { params: ['email'] }),
                       },
                     }),
                   },
@@ -2151,7 +2173,7 @@ describe('OpenapiEndpointRenderer', () => {
                 type: 'object',
                 required: ['pet'],
                 properties: {
-                  pet: OpenAPI.forDream(Pet, { only: ['name'] }),
+                  pet: OpenAPI.forDream(Pet, { params: ['name'] }),
                 },
               },
             })
@@ -2186,7 +2208,7 @@ describe('OpenapiEndpointRenderer', () => {
                 properties: {
                   pets: {
                     type: 'array',
-                    items: OpenAPI.forDream(Pet, { only: ['name'] }),
+                    items: OpenAPI.forDream(Pet, { params: ['name'] }),
                   },
                 },
               },
@@ -2211,7 +2233,7 @@ describe('OpenapiEndpointRenderer', () => {
           it('hand-rolled nested object fragments continue to render identically', () => {
             const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
               requestBody: {
-                only: ['email'],
+                params: ['email'],
                 combining: {
                   items: {
                     type: 'array',
@@ -2246,11 +2268,11 @@ describe('OpenapiEndpointRenderer', () => {
         })
 
         it('type test - ensure OpenAPI.forDream column-name options are constrained to the model and that nested for: is rejected in response shorthand', () => {
-          // valid: param-safe column names in only/including/required
-          OpenAPI.forDream(Pet, { only: ['name'], including: ['userId'], required: ['name'] })
+          // valid: param-safe column names in params/including/required
+          OpenAPI.forDream(Pet, { params: ['name'], including: ['userId'], required: ['name'] })
 
           // @ts-expect-error — 'notARealColumn' is not a column of Pet
-          OpenAPI.forDream(Pet, { only: ['notARealColumn'] })
+          OpenAPI.forDream(Pet, { params: ['notARealColumn'] })
 
           // @ts-expect-error — 'notARealColumn' is not a column of Pet
           OpenAPI.forDream(Pet, { including: ['notARealColumn'] })

--- a/src/controller/decorators.ts
+++ b/src/controller/decorators.ts
@@ -142,9 +142,9 @@ export function OpenAPI(
 export namespace OpenAPI {
   /**
    * Type-narrowed helper for nesting a Dream-model-driven shape inside a
-   * request body. Returns the same `{ for, only, including, required,
+   * request body. Returns the same `{ for, params, including, required,
    * combining }` shape the renderer recognizes natively, but typed via a
-   * function-level generic so `only` / `including` / `required` are
+   * function-level generic so `params` / `including` / `required` are
    * constrained to columns of the model passed as the first argument.
    *
    * ```ts
@@ -173,6 +173,11 @@ export namespace OpenAPI {
   export function forDream<const M extends typeof Dream>(
     model: M,
     opts: {
+      params?: readonly (keyof DreamParamSafeAttributes<InstanceType<M>>)[]
+      /**
+       * @deprecated Use `params` instead. `only` remains as a compatibility alias
+       * for apps written before `extractParams` made request params explicit.
+       */
       only?: readonly (keyof DreamParamSafeAttributes<InstanceType<M>>)[]
       including?: readonly Exclude<
         keyof UpdateableProperties<InstanceType<M>>,

--- a/src/generate/helpers/generateControllerContent.ts
+++ b/src/generate/helpers/generateControllerContent.ts
@@ -87,7 +87,7 @@ export default function generateControllerContent({
     description: 'Create ${aOrAnDreamModelName(modelClassName!)}',${defaultOpenapiSerializerKeyProperty}
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async create() {
@@ -169,7 +169,7 @@ export default function generateControllerContent({
     description: 'Update ${aOrAnDreamModelName(modelClassName!)}',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async update() {

--- a/src/openapi-renderer/body-segment.ts
+++ b/src/openapi-renderer/body-segment.ts
@@ -59,7 +59,7 @@ export interface OpenapiBodySegmentRendererOpts {
  * - Nullable array shorthands like `['string[]', 'null']` → `{ type: ['array', 'null'], items: { type: 'string' } }`
  * - Serializer references like `{ $serializer: SomeSerializer }` → `{ $ref: '#/components/schemas/SerializerOpenapiName' }`
  * - Serializable references like `{ $serializable: SomeModel, key: 'summary' }` → resolved serializer reference
- * - Nested model-derived request-body references like `{ for: SomeModel, including, only, required, combining }` → an inline object schema derived from the model's param-safe columns (request-only)
+ * - Nested model-derived request-body references like `{ for: SomeModel, params, including, required, combining }` → an inline object schema derived from the model's param-safe columns (request-only)
  *
  * The class recursively processes nested structures (objects, arrays, unions) and maintains
  * a collection of referenced serializers that need to be included in the final OpenAPI document.
@@ -628,6 +628,7 @@ The following values will be allowed:
 
     const ref = bodySegment as unknown as {
       for: typeof Dream
+      params?: readonly string[]
       including?: readonly string[]
       only?: readonly string[]
       required?: readonly string[]
@@ -637,6 +638,7 @@ The following values will be allowed:
     const paramsShape = buildDreamRequestBodyShape(
       ref.for,
       {
+        params: ref.params,
         only: ref.only,
         including: ref.including,
         required: ref.required,

--- a/src/openapi-renderer/endpoint.ts
+++ b/src/openapi-renderer/endpoint.ts
@@ -667,6 +667,7 @@ export default class OpenapiEndpointRenderer<
   private shouldAutogenerateBody() {
     const body = this.requestBody as OpenapiSchemaRequestBodyForOption<typeof Dream>
     if (!body) return true
+    if (body.params) return true
     if (body.only) return true
     if (body.including) return true
     if (body.combining) return true
@@ -694,13 +695,14 @@ export default class OpenapiEndpointRenderer<
     const dreamClass = forDreamClass || this.getSingleDreamModelClass()
     if (!dreamClass) return this.defaultRequestBody()
 
-    const { only, including, required, combining } = (this.requestBody ||
+    const { params, only, including, required, combining } = (this.requestBody ||
       {}) as OpenapiSchemaRequestBodyForOption<typeof Dream>
 
     const source = this.controllerClass.controllerActionPath(this.action)
     const paramsShape = buildDreamRequestBodyShape(
       dreamClass,
       {
+        params: params as readonly string[] | undefined,
         only: only as readonly string[] | undefined,
         including: including as readonly string[] | undefined,
         required: required as readonly string[] | undefined,
@@ -1678,8 +1680,13 @@ type DreamShorthandPrev = [never, 0, 1, 2, 3]
  */
 export type OpenapiSchemaNestedFor<Depth extends 0 | 1 | 2 | 3 = 3> = {
   for: typeof Dream
-  including?: readonly string[]
+  params?: readonly string[]
+  /**
+   * @deprecated Use `params` instead. `only` remains as a compatibility alias
+   * for apps written before `extractParams` made request params explicit.
+   */
   only?: readonly string[]
+  including?: readonly string[]
   required?: readonly string[]
   combining?: Depth extends 0
     ? OpenapiSchemaPropertiesShorthand
@@ -1747,15 +1754,14 @@ export interface OpenapiSchemaRequestBodyForDreamClass<ForOption extends typeof 
   for: ForOption
 
   /**
-   * Narrow down which fields on the model you would like
-   * to include. If a `for` option is provided, the fields
-   * will be derived from that model class. Otherwise, it
-   * will be derrived from the first argument passed to
-   * the OpenAPI decorator, provided it is a dream model.
+   * Explicitly list which request params to include from the model. If a `for`
+   * option is provided, the params will be derived from that model class.
+   * Otherwise, they will be derived from the first argument passed to the
+   * OpenAPI decorator, provided it is a Dream model.
    *
    * ```ts
    * @OpenAPI({
-   *   requestBody: { for: Pet, only: ['species', 'name'] }
+   *   requestBody: { for: Pet, params: ['species', 'name'] }
    * })
    * public create() {
    *   ...
@@ -1766,12 +1772,18 @@ export interface OpenapiSchemaRequestBodyForDreamClass<ForOption extends typeof 
    *
    * ```ts
    * @OpenAPI(Pet, {
-   *   requestBody: { only: ['species', 'name'] }
+   *   requestBody: { params: ['species', 'name'] }
    * })
    * public create() {
    *   ...
    * }
    * ```
+   */
+  params?: (keyof DreamParamSafeAttributes<InstanceType<ForOption>>)[]
+
+  /**
+   * @deprecated Use `params` instead. `only` remains as a compatibility alias
+   * for apps written before `extractParams` made request params explicit.
    */
   only?: (keyof DreamParamSafeAttributes<InstanceType<ForOption>>)[]
 
@@ -1826,7 +1838,7 @@ export interface OpenapiSchemaRequestBodyForDreamClass<ForOption extends typeof 
    * `combining` values may also be a nested `for:` sentinel — the same
    * shape as the top-level model-driven `requestBody`, just nested. It
    * derives an object schema from another Dream model's param-safe
-   * columns and accepts the same `including` / `only` / `required` /
+   * columns and accepts the same `params` / `including` / `required` /
    * `combining` siblings.
    *
    * ```ts
@@ -1902,20 +1914,25 @@ export interface OpenapiSchemaRequestBodyForBaseDreamClass<
   for?: never
 
   /**
-   * Narrow down which fields on the model you would like
-   * to include. If a `for` option is provided, the fields
-   * will be derived from that model class. Otherwise, it
-   * will be derrived from the first argument passed to
-   * the OpenAPI decorator, provided it is a dream model.
+   * Explicitly list which request params to include from the model. If a `for`
+   * option is provided, the params will be derived from that model class.
+   * Otherwise, they will be derived from the first argument passed to the
+   * OpenAPI decorator, provided it is a Dream model.
    *
    * ```ts
    * @OpenAPI(Pet, {
-   *   requestBody: { only: ['species', 'name'] }
+   *   requestBody: { params: ['species', 'name'] }
    * })
    * public create() {
    *   ...
    * }
    * ```
+   */
+  params?: Only
+
+  /**
+   * @deprecated Use `params` instead. `only` remains as a compatibility alias
+   * for apps written before `extractParams` made request params explicit.
    */
   only?: Only
 
@@ -1956,7 +1973,7 @@ export interface OpenapiSchemaRequestBodyForBaseDreamClass<
    * `combining` values may also be a nested `for:` sentinel — the same
    * shape as the top-level model-driven `requestBody`, just nested. It
    * derives an object schema from another Dream model's param-safe
-   * columns and accepts the same `including` / `only` / `required` /
+   * columns and accepts the same `params` / `including` / `required` /
    * `combining` siblings.
    *
    * ```ts

--- a/src/openapi-renderer/helpers/buildDreamRequestBodyShape.ts
+++ b/src/openapi-renderer/helpers/buildDreamRequestBodyShape.ts
@@ -5,6 +5,7 @@ import openapiParamNamesForDreamClass from '../../server/helpers/openapiParamNam
 import { dreamColumnOpenapiShape } from './dreamColumnOpenapiShape.js'
 
 export interface BuildDreamRequestBodyShapeOpts {
+  params?: readonly string[] | undefined
   only?: readonly string[] | undefined
   including?: readonly string[] | undefined
   required?: readonly string[] | undefined
@@ -26,9 +27,12 @@ export default function buildDreamRequestBodyShape(
   opts: BuildDreamRequestBodyShapeOpts,
   source: string,
 ): OpenapiSchemaObject {
-  const { only, including, required, combining } = opts
+  const { params, only, including, required, combining } = opts
 
-  const paramSafeColumns = openapiParamNamesForDreamClass(dreamClass, { only, including } as any)
+  const paramSafeColumns = openapiParamNamesForDreamClass(dreamClass, {
+    only: params ?? only,
+    including,
+  } as any)
 
   const paramsShape: OpenapiSchemaObject = {
     type: 'object',

--- a/src/server/params.ts
+++ b/src/server/params.ts
@@ -683,6 +683,7 @@ export interface ExtractParamsOpts {
 
 export interface OpenAPIDreamModelRequestBodyModifications<OnlyArray, IncludingArray>
   extends ParamsForOptsBase<OnlyArray> {
+  params?: OnlyArray
   combining?: OpenapiSchemaPropertiesShorthand
   including?: IncludingArray
 }


### PR DESCRIPTION
## Summary

- Adds `requestBody.params` as the canonical OpenAPI model-derived request param allowlist.
- Keeps `requestBody.only` as a deprecated compatibility alias, including nested `{ for: Model }` shorthand and `OpenAPI.forDream`.
- Updates generated create/update controller scaffolds to emit `params: paramSafeColumns`.
- Bumps `@rvoh/psychic` to `3.7.1` and documents the migration in the changelog.

## Verification

- `pnpm uspec spec/unit/openapi-renderer/endpoint/toPathObject.spec.ts`
- `pnpm uspec spec/unit/generate/helpers/generateControllerContent.spec.ts`
- `pnpm build:test-app`
- `pnpm lint`
