### PR TITLE
Cast virtual params from OpenAPI metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 3.7.1
+## 3.8.0
 
 - `Params.for` and `PsychicController#extractParams` now cast and validate Dream virtual columns, including `@Encrypted` fields, from their declared OpenAPI metadata instead of passing them through unchecked. This makes virtual param handling match concrete Dream columns: `@Virtual(['string', 'null'])` and nullable `@Encrypted` params reject non-strings while allowing `null`, and virtual array shorthands such as `string[]` are cast through the same array path used for database-backed array columns.
+- `@OpenAPI` model-derived `requestBody` allowlists now use `params` as the canonical key (`requestBody: { params: paramSafeColumns }`) to match the explicit `extractParams(Model, paramSafeColumns)` flow. The previous `only` key still works as a deprecated compatibility alias, including inside nested `{ for: Model }` request-body shorthand and `OpenAPI.forDream(Model, ...)`, but newly generated `create` / `update` scaffolds emit `params` so the documented request shape and runtime extraction call both read as explicit request params.
 
 ## 3.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.1
+
+- `Params.for` and `PsychicController#extractParams` now cast and validate Dream virtual columns, including `@Encrypted` fields, from their declared OpenAPI metadata instead of passing them through unchecked. This makes virtual param handling match concrete Dream columns: `@Virtual(['string', 'null'])` and nullable `@Encrypted` params reject non-strings while allowing `null`, and virtual array shorthands such as `string[]` are cast through the same array path used for database-backed array columns.
+
 ## 3.7.0
 
 - `g:resource` controllers generated in the `internal` namespace now scope queries to the authenticated internal user the same way default-namespace controllers scope to the current user — `this.currentInternalUser.associationQuery('posts')` / `this.currentInternalUser.createAssociation('posts', …)` — instead of reaching every record in the system via direct model access. Previously the `internal` namespace was treated identically to `admin`, lifting all owner scoping; that meant a generated internal resource defaulted to letting any authenticated internal user read and mutate any record, an unsafe default for a scaffold. The `admin` namespace is unchanged (still unscoped by default), and supplying `--owning-model` still scopes to that model in either namespace. The generated resource spec gains the matching "created by another InternalUser" omission/not-found/not-updated/not-deleted contexts. Generated scaffolds are emitted commented-out, so this only affects newly generated code — no runtime behavior in existing apps changes.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.7.1",
+  "version": "3.8.0",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/spec/unit/generate/helpers/generateControllerContent.spec.ts
+++ b/spec/unit/generate/helpers/generateControllerContent.spec.ts
@@ -59,7 +59,7 @@ export default class PostsController extends AuthedController {
     description: 'Create a Post',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async create() {
@@ -74,7 +74,7 @@ export default class PostsController extends AuthedController {
     description: 'Update a Post',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async update() {
@@ -157,7 +157,7 @@ export default class HostingAgreementController extends AuthedController {
     description: 'Create a HostingAgreement',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async create() {
@@ -172,7 +172,7 @@ export default class HostingAgreementController extends AuthedController {
     description: 'Update a HostingAgreement',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async update() {
@@ -261,7 +261,7 @@ export default class ApiV1HealthPostsController extends AuthedController {
     description: 'Create a HealthPost',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async create() {
@@ -276,7 +276,7 @@ export default class ApiV1HealthPostsController extends AuthedController {
     description: 'Update a HealthPost',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async update() {
@@ -418,7 +418,7 @@ export default class PostsController extends AuthedController {
     description: 'Create a Post',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async create() {
@@ -433,7 +433,7 @@ export default class PostsController extends AuthedController {
     description: 'Update a Post',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async update() {
@@ -537,7 +537,7 @@ export default class AdminArticlesController extends AdminAuthedController {
     serializerKey: 'admin',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async create() {
@@ -552,7 +552,7 @@ export default class AdminArticlesController extends AdminAuthedController {
     description: 'Update a Article',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async update() {
@@ -654,7 +654,7 @@ export default class AdminArticlesController extends AdminAuthedController {
     serializerKey: 'admin',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async create() {
@@ -669,7 +669,7 @@ export default class AdminArticlesController extends AdminAuthedController {
     description: 'Update a Article',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async update() {
@@ -764,7 +764,7 @@ export default class InternalArticlesController extends InternalAuthedController
     serializerKey: 'internal',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async create() {
@@ -779,7 +779,7 @@ export default class InternalArticlesController extends InternalAuthedController
     description: 'Update a Article',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async update() {
@@ -882,7 +882,7 @@ export default class InternalArticlesController extends InternalAuthedController
     serializerKey: 'internal',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async create() {
@@ -897,7 +897,7 @@ export default class InternalArticlesController extends InternalAuthedController
     description: 'Update a Article',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async update() {

--- a/spec/unit/openapi-renderer/endpoint/toPathObject.spec.ts
+++ b/spec/unit/openapi-renderer/endpoint/toPathObject.spec.ts
@@ -1263,8 +1263,30 @@ describe('OpenapiEndpointRenderer', () => {
           })
         })
 
-        context('with only provided', () => {
+        context('with params provided', () => {
           it('excludes params to the list provided', () => {
+            const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
+              requestBody: { params: ['email'] },
+            })
+
+            const response = renderer.toPathObject(routes, defaultToPathObjectOpts()).openapi
+            expect(response['/users']!.post.requestBody).toEqual({
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      email: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            })
+          })
+
+          it('supports only as a deprecated alias', () => {
             const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
               requestBody: { only: ['email'] },
             })
@@ -1290,7 +1312,7 @@ describe('OpenapiEndpointRenderer', () => {
         context('with including provided', () => {
           it('includes params provided by the list', () => {
             const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
-              requestBody: { only: ['email'], including: ['id'] },
+              requestBody: { params: ['email'], including: ['id'] },
             })
 
             const response = renderer.toPathObject(routes, defaultToPathObjectOpts()).openapi
@@ -1343,7 +1365,7 @@ describe('OpenapiEndpointRenderer', () => {
           context('with including provided with blank only', () => {
             it('includes params provided by the including list exclusively', () => {
               const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
-                requestBody: { including: ['id'], only: [] },
+                requestBody: { including: ['id'], params: [] },
               })
 
               const response = renderer.toPathObject(routes, defaultToPathObjectOpts()).openapi
@@ -1401,7 +1423,7 @@ describe('OpenapiEndpointRenderer', () => {
             it('combines whatever is provided to combining along with the only/including args', () => {
               const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
                 requestBody: {
-                  only: ['email'],
+                  params: ['email'],
                   including: ['id'],
                   combining: {
                     name: 'string',
@@ -1436,10 +1458,10 @@ describe('OpenapiEndpointRenderer', () => {
         })
       })
 
-      context('requestBody leverages only opt', () => {
-        it('only renders attributes specified in only array', () => {
+      context('requestBody leverages params opt', () => {
+        it('only renders attributes specified in params array', () => {
           const renderer = new OpenapiEndpointRenderer(Pet, ApiPetsController, 'create', {
-            requestBody: { only: ['species', 'name'] },
+            requestBody: { params: ['species', 'name'] },
           })
 
           const response = renderer.toPathObject(routes, defaultToPathObjectOpts()).openapi
@@ -1465,7 +1487,7 @@ describe('OpenapiEndpointRenderer', () => {
           context('requestBody leverages required opt', () => {
             it('renders the required options in the required field', () => {
               const renderer = new OpenapiEndpointRenderer(Pet, ApiPetsController, 'create', {
-                requestBody: { only: ['species', 'name'], required: ['species'] },
+                requestBody: { params: ['species', 'name'], required: ['species'] },
               })
 
               const response = renderer.toPathObject(routes, defaultToPathObjectOpts()).openapi
@@ -1492,7 +1514,7 @@ describe('OpenapiEndpointRenderer', () => {
           context('requestBody leverages for opt', () => {
             it('uses the model provided in the for option to determine request body shape', () => {
               const renderer = new OpenapiEndpointRenderer(Pet, ApiPetsController, 'create', {
-                requestBody: { for: User, only: ['email'], required: ['id'], including: ['id'] },
+                requestBody: { for: User, params: ['email'], required: ['id'], including: ['id'] },
               })
 
               const response = renderer.toPathObject(routes, defaultToPathObjectOpts()).openapi
@@ -1515,7 +1537,7 @@ describe('OpenapiEndpointRenderer', () => {
             context('requestBody leverages for opt with virtual attributes', () => {
               it('includes virtual attributes in the request body', () => {
                 const renderer = new OpenapiEndpointRenderer(Pet, ApiPetsController, 'create', {
-                  requestBody: { for: User, only: ['openapiVirtualSpecTest'] },
+                  requestBody: { for: User, params: ['openapiVirtualSpecTest'] },
                 })
 
                 const response = renderer.toPathObject(routes, defaultToPathObjectOpts()).openapi
@@ -2013,7 +2035,7 @@ describe('OpenapiEndpointRenderer', () => {
           it("expands OpenAPI.forDream(Model) into an object schema using that model's param-safe columns", () => {
             const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
               requestBody: {
-                only: ['email'],
+                params: ['email'],
                 combining: {
                   pets: {
                     type: 'array',
@@ -2041,7 +2063,7 @@ describe('OpenapiEndpointRenderer', () => {
           it('attaches required on the nested model schema, not on the outer array', () => {
             const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
               requestBody: {
-                only: ['email'],
+                params: ['email'],
                 combining: {
                   pets: {
                     type: 'array',
@@ -2066,7 +2088,7 @@ describe('OpenapiEndpointRenderer', () => {
           it('adds the included column to the nested model schema', () => {
             const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
               requestBody: {
-                only: ['email'],
+                params: ['email'],
                 combining: {
                   pets: {
                     type: 'array',
@@ -2088,11 +2110,11 @@ describe('OpenapiEndpointRenderer', () => {
           it('narrows the nested model schema to just the listed columns', () => {
             const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
               requestBody: {
-                only: ['email'],
+                params: ['email'],
                 combining: {
                   pets: {
                     type: 'array',
-                    items: OpenAPI.forDream(Pet, { only: ['name'] }),
+                    items: OpenAPI.forDream(Pet, { params: ['name'] }),
                   },
                 },
               },
@@ -2114,14 +2136,14 @@ describe('OpenapiEndpointRenderer', () => {
           it('expands an OpenAPI.forDream nested inside another forDream call combining', () => {
             const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
               requestBody: {
-                only: ['email'],
+                params: ['email'],
                 combining: {
                   pets: {
                     type: 'array',
                     items: OpenAPI.forDream(Pet, {
-                      only: ['name'],
+                      params: ['name'],
                       combining: {
-                        owner: OpenAPI.forDream(User, { only: ['email'] }),
+                        owner: OpenAPI.forDream(User, { params: ['email'] }),
                       },
                     }),
                   },
@@ -2151,7 +2173,7 @@ describe('OpenapiEndpointRenderer', () => {
                 type: 'object',
                 required: ['pet'],
                 properties: {
-                  pet: OpenAPI.forDream(Pet, { only: ['name'] }),
+                  pet: OpenAPI.forDream(Pet, { params: ['name'] }),
                 },
               },
             })
@@ -2186,7 +2208,7 @@ describe('OpenapiEndpointRenderer', () => {
                 properties: {
                   pets: {
                     type: 'array',
-                    items: OpenAPI.forDream(Pet, { only: ['name'] }),
+                    items: OpenAPI.forDream(Pet, { params: ['name'] }),
                   },
                 },
               },
@@ -2211,7 +2233,7 @@ describe('OpenapiEndpointRenderer', () => {
           it('hand-rolled nested object fragments continue to render identically', () => {
             const renderer = new OpenapiEndpointRenderer(User, UsersController, 'create', {
               requestBody: {
-                only: ['email'],
+                params: ['email'],
                 combining: {
                   items: {
                     type: 'array',
@@ -2246,11 +2268,11 @@ describe('OpenapiEndpointRenderer', () => {
         })
 
         it('type test - ensure OpenAPI.forDream column-name options are constrained to the model and that nested for: is rejected in response shorthand', () => {
-          // valid: param-safe column names in only/including/required
-          OpenAPI.forDream(Pet, { only: ['name'], including: ['userId'], required: ['name'] })
+          // valid: param-safe column names in params/including/required
+          OpenAPI.forDream(Pet, { params: ['name'], including: ['userId'], required: ['name'] })
 
           // @ts-expect-error — 'notARealColumn' is not a column of Pet
-          OpenAPI.forDream(Pet, { only: ['notARealColumn'] })
+          OpenAPI.forDream(Pet, { params: ['notARealColumn'] })
 
           // @ts-expect-error — 'notARealColumn' is not a column of Pet
           OpenAPI.forDream(Pet, { including: ['notARealColumn'] })

--- a/spec/unit/server/params.spec.ts
+++ b/spec/unit/server/params.spec.ts
@@ -84,6 +84,24 @@ describe('Params', () => {
       })
     })
 
+    context('@Encrypted attributes', () => {
+      it('casts the decorated property from its inferred OpenAPI shape', () => {
+        expect(Params.for({ secret: 'shh' }, User)).toEqual({ secret: 'shh' })
+      })
+
+      it('permits null when the backing encrypted column allows null', () => {
+        expect(Params.for({ secret: null }, User)).toEqual({ secret: null })
+      })
+
+      it('rejects values that do not match the inferred OpenAPI shape', () => {
+        expect(() => Params.for({ secret: 123 }, User)).toThrow(ParamValidationErrors)
+      })
+
+      it('does not extract the encrypted backing column', () => {
+        expect(Params.for({ encryptedSecret: 'ciphertext' }, User)).toEqual({})
+      })
+    })
+
     context('array option is true', () => {
       it('expects top-level array', () => {
         expect(Params.for([{ id: 123, email: 'how', password: 'yadoin' }], User, { array: true })).toEqual([
@@ -869,6 +887,20 @@ describe('Params', () => {
 
   describe('#cast', () => {
     context('data types', () => {
+      context('OpenAPI schemas', () => {
+        const shape = {
+          type: 'object' as const,
+          properties: {
+            name: { type: 'string' as const },
+          },
+          required: ['name'],
+        }
+
+        it('validates nullish values against the OpenAPI schema', () => {
+          expect(() => Params.cast({ user: null }, 'user', shape)).toThrow(ParamValidationError)
+        })
+      })
+
       context('primitive values', () => {
         context('string', () => {
           context('with a valid value', () => {

--- a/spec/unit/server/params.spec.ts
+++ b/spec/unit/server/params.spec.ts
@@ -65,6 +65,23 @@ describe('Params', () => {
           password: 'yadoin',
         })
       })
+
+      it('validates virtual attributes against their OpenAPI shape', () => {
+        expect(() => Params.for({ password: 123 }, User)).toThrow(ParamValidationErrors)
+      })
+
+      it('permits null for nullable virtual attributes', () => {
+        expect(Params.for({ password: null }, User)).toEqual({ password: null })
+      })
+
+      it('validates virtual array attributes against their OpenAPI shape', () => {
+        expect(Params.for({ openapiVirtualSpecTest2: ['howdy'] }, User)).toEqual({
+          openapiVirtualSpecTest2: ['howdy'],
+        })
+        expect(Params.for({ openapiVirtualSpecTest2: 'howdy' }, User)).toEqual({
+          openapiVirtualSpecTest2: ['howdy'],
+        })
+      })
     })
 
     context('array option is true', () => {

--- a/src/controller/decorators.ts
+++ b/src/controller/decorators.ts
@@ -142,9 +142,9 @@ export function OpenAPI(
 export namespace OpenAPI {
   /**
    * Type-narrowed helper for nesting a Dream-model-driven shape inside a
-   * request body. Returns the same `{ for, only, including, required,
+   * request body. Returns the same `{ for, params, including, required,
    * combining }` shape the renderer recognizes natively, but typed via a
-   * function-level generic so `only` / `including` / `required` are
+   * function-level generic so `params` / `including` / `required` are
    * constrained to columns of the model passed as the first argument.
    *
    * ```ts
@@ -173,6 +173,11 @@ export namespace OpenAPI {
   export function forDream<const M extends typeof Dream>(
     model: M,
     opts: {
+      params?: readonly (keyof DreamParamSafeAttributes<InstanceType<M>>)[]
+      /**
+       * @deprecated Use `params` instead. `only` remains as a compatibility alias
+       * for apps written before `extractParams` made request params explicit.
+       */
       only?: readonly (keyof DreamParamSafeAttributes<InstanceType<M>>)[]
       including?: readonly Exclude<
         keyof UpdateableProperties<InstanceType<M>>,

--- a/src/generate/helpers/generateControllerContent.ts
+++ b/src/generate/helpers/generateControllerContent.ts
@@ -87,7 +87,7 @@ export default function generateControllerContent({
     description: 'Create ${aOrAnDreamModelName(modelClassName!)}',${defaultOpenapiSerializerKeyProperty}
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async create() {
@@ -169,7 +169,7 @@ export default function generateControllerContent({
     description: 'Update ${aOrAnDreamModelName(modelClassName!)}',
     fastJsonStringify: true,
     requestBody: {
-      only: paramSafeColumns,
+      params: paramSafeColumns,
     },
   })
   public async update() {

--- a/src/openapi-renderer/body-segment.ts
+++ b/src/openapi-renderer/body-segment.ts
@@ -59,7 +59,7 @@ export interface OpenapiBodySegmentRendererOpts {
  * - Nullable array shorthands like `['string[]', 'null']` → `{ type: ['array', 'null'], items: { type: 'string' } }`
  * - Serializer references like `{ $serializer: SomeSerializer }` → `{ $ref: '#/components/schemas/SerializerOpenapiName' }`
  * - Serializable references like `{ $serializable: SomeModel, key: 'summary' }` → resolved serializer reference
- * - Nested model-derived request-body references like `{ for: SomeModel, including, only, required, combining }` → an inline object schema derived from the model's param-safe columns (request-only)
+ * - Nested model-derived request-body references like `{ for: SomeModel, params, including, required, combining }` → an inline object schema derived from the model's param-safe columns (request-only)
  *
  * The class recursively processes nested structures (objects, arrays, unions) and maintains
  * a collection of referenced serializers that need to be included in the final OpenAPI document.
@@ -628,6 +628,7 @@ The following values will be allowed:
 
     const ref = bodySegment as unknown as {
       for: typeof Dream
+      params?: readonly string[]
       including?: readonly string[]
       only?: readonly string[]
       required?: readonly string[]
@@ -637,6 +638,7 @@ The following values will be allowed:
     const paramsShape = buildDreamRequestBodyShape(
       ref.for,
       {
+        params: ref.params,
         only: ref.only,
         including: ref.including,
         required: ref.required,

--- a/src/openapi-renderer/endpoint.ts
+++ b/src/openapi-renderer/endpoint.ts
@@ -667,6 +667,7 @@ export default class OpenapiEndpointRenderer<
   private shouldAutogenerateBody() {
     const body = this.requestBody as OpenapiSchemaRequestBodyForOption<typeof Dream>
     if (!body) return true
+    if (body.params) return true
     if (body.only) return true
     if (body.including) return true
     if (body.combining) return true
@@ -694,13 +695,14 @@ export default class OpenapiEndpointRenderer<
     const dreamClass = forDreamClass || this.getSingleDreamModelClass()
     if (!dreamClass) return this.defaultRequestBody()
 
-    const { only, including, required, combining } = (this.requestBody ||
+    const { params, only, including, required, combining } = (this.requestBody ||
       {}) as OpenapiSchemaRequestBodyForOption<typeof Dream>
 
     const source = this.controllerClass.controllerActionPath(this.action)
     const paramsShape = buildDreamRequestBodyShape(
       dreamClass,
       {
+        params: params as readonly string[] | undefined,
         only: only as readonly string[] | undefined,
         including: including as readonly string[] | undefined,
         required: required as readonly string[] | undefined,
@@ -1678,8 +1680,13 @@ type DreamShorthandPrev = [never, 0, 1, 2, 3]
  */
 export type OpenapiSchemaNestedFor<Depth extends 0 | 1 | 2 | 3 = 3> = {
   for: typeof Dream
-  including?: readonly string[]
+  params?: readonly string[]
+  /**
+   * @deprecated Use `params` instead. `only` remains as a compatibility alias
+   * for apps written before `extractParams` made request params explicit.
+   */
   only?: readonly string[]
+  including?: readonly string[]
   required?: readonly string[]
   combining?: Depth extends 0
     ? OpenapiSchemaPropertiesShorthand
@@ -1747,15 +1754,14 @@ export interface OpenapiSchemaRequestBodyForDreamClass<ForOption extends typeof 
   for: ForOption
 
   /**
-   * Narrow down which fields on the model you would like
-   * to include. If a `for` option is provided, the fields
-   * will be derived from that model class. Otherwise, it
-   * will be derrived from the first argument passed to
-   * the OpenAPI decorator, provided it is a dream model.
+   * Explicitly list which request params to include from the model. If a `for`
+   * option is provided, the params will be derived from that model class.
+   * Otherwise, they will be derived from the first argument passed to the
+   * OpenAPI decorator, provided it is a Dream model.
    *
    * ```ts
    * @OpenAPI({
-   *   requestBody: { for: Pet, only: ['species', 'name'] }
+   *   requestBody: { for: Pet, params: ['species', 'name'] }
    * })
    * public create() {
    *   ...
@@ -1766,12 +1772,18 @@ export interface OpenapiSchemaRequestBodyForDreamClass<ForOption extends typeof 
    *
    * ```ts
    * @OpenAPI(Pet, {
-   *   requestBody: { only: ['species', 'name'] }
+   *   requestBody: { params: ['species', 'name'] }
    * })
    * public create() {
    *   ...
    * }
    * ```
+   */
+  params?: (keyof DreamParamSafeAttributes<InstanceType<ForOption>>)[]
+
+  /**
+   * @deprecated Use `params` instead. `only` remains as a compatibility alias
+   * for apps written before `extractParams` made request params explicit.
    */
   only?: (keyof DreamParamSafeAttributes<InstanceType<ForOption>>)[]
 
@@ -1826,7 +1838,7 @@ export interface OpenapiSchemaRequestBodyForDreamClass<ForOption extends typeof 
    * `combining` values may also be a nested `for:` sentinel — the same
    * shape as the top-level model-driven `requestBody`, just nested. It
    * derives an object schema from another Dream model's param-safe
-   * columns and accepts the same `including` / `only` / `required` /
+   * columns and accepts the same `params` / `including` / `required` /
    * `combining` siblings.
    *
    * ```ts
@@ -1902,20 +1914,25 @@ export interface OpenapiSchemaRequestBodyForBaseDreamClass<
   for?: never
 
   /**
-   * Narrow down which fields on the model you would like
-   * to include. If a `for` option is provided, the fields
-   * will be derived from that model class. Otherwise, it
-   * will be derrived from the first argument passed to
-   * the OpenAPI decorator, provided it is a dream model.
+   * Explicitly list which request params to include from the model. If a `for`
+   * option is provided, the params will be derived from that model class.
+   * Otherwise, they will be derived from the first argument passed to the
+   * OpenAPI decorator, provided it is a Dream model.
    *
    * ```ts
    * @OpenAPI(Pet, {
-   *   requestBody: { only: ['species', 'name'] }
+   *   requestBody: { params: ['species', 'name'] }
    * })
    * public create() {
    *   ...
    * }
    * ```
+   */
+  params?: Only
+
+  /**
+   * @deprecated Use `params` instead. `only` remains as a compatibility alias
+   * for apps written before `extractParams` made request params explicit.
    */
   only?: Only
 
@@ -1956,7 +1973,7 @@ export interface OpenapiSchemaRequestBodyForBaseDreamClass<
    * `combining` values may also be a nested `for:` sentinel — the same
    * shape as the top-level model-driven `requestBody`, just nested. It
    * derives an object schema from another Dream model's param-safe
-   * columns and accepts the same `including` / `only` / `required` /
+   * columns and accepts the same `params` / `including` / `required` /
    * `combining` siblings.
    *
    * ```ts

--- a/src/openapi-renderer/helpers/buildDreamRequestBodyShape.ts
+++ b/src/openapi-renderer/helpers/buildDreamRequestBodyShape.ts
@@ -5,6 +5,7 @@ import openapiParamNamesForDreamClass from '../../server/helpers/openapiParamNam
 import { dreamColumnOpenapiShape } from './dreamColumnOpenapiShape.js'
 
 export interface BuildDreamRequestBodyShapeOpts {
+  params?: readonly string[] | undefined
   only?: readonly string[] | undefined
   including?: readonly string[] | undefined
   required?: readonly string[] | undefined
@@ -26,9 +27,12 @@ export default function buildDreamRequestBodyShape(
   opts: BuildDreamRequestBodyShapeOpts,
   source: string,
 ): OpenapiSchemaObject {
-  const { only, including, required, combining } = opts
+  const { params, only, including, required, combining } = opts
 
-  const paramSafeColumns = openapiParamNamesForDreamClass(dreamClass, { only, including } as any)
+  const paramSafeColumns = openapiParamNamesForDreamClass(dreamClass, {
+    only: params ?? only,
+    including,
+  } as any)
 
   const paramsShape: OpenapiSchemaObject = {
     type: 'object',

--- a/src/server/helpers/openapiParamNamesForDreamClass.ts
+++ b/src/server/helpers/openapiParamNamesForDreamClass.ts
@@ -5,8 +5,8 @@ import {
   StrictInterface,
   UpdateableProperties,
 } from '@rvoh/dream/types'
-import { VirtualAttributeStatement } from '../../openapi-renderer/helpers/dreamColumnOpenapiShape.js'
-import { OpenAPIDreamModelRequestBodyModifications } from '../params.js'
+import type { VirtualAttributeStatement } from '../../openapi-renderer/helpers/dreamColumnOpenapiShape.js'
+import type { OpenAPIDreamModelRequestBodyModifications } from '../params.js'
 import paramNamesForDreamClass from './paramNamesForDreamClass.js'
 
 export default function openapiParamNamesForDreamClass<

--- a/src/server/helpers/paramNamesForDreamClass.ts
+++ b/src/server/helpers/paramNamesForDreamClass.ts
@@ -1,6 +1,6 @@
 import { Dream } from '@rvoh/dream'
 import { DreamParamSafeAttributes, DreamParamSafeColumnNames, StrictInterface } from '@rvoh/dream/types'
-import { ParamsForOpts } from '../params.js'
+import type { ParamsForOpts } from '../params.js'
 
 export default function paramNamesForDreamClass<
   T extends typeof Dream,

--- a/src/server/params.ts
+++ b/src/server/params.ts
@@ -292,7 +292,7 @@ export default class Params {
     if (paramValue === null || paramValue === undefined) {
       if (expectedType === 'null') return null as ReturnType
       if (this.shouldUseOpenapiValidation(expectedType)) {
-        return paramValue as ReturnType
+        return this.validateOpenapiOrThrow(paramName, paramValue, expectedType) as ReturnType
       }
 
       this.throwUnlessAllowNull(
@@ -457,7 +457,7 @@ export default class Params {
 
   private shouldUseOpenapiValidation<
     ExpectedType extends PsychicParamsPrimitiveLiteral | RegExp | OpenapiSchemaBody,
-  >(expectedType: ExpectedType): boolean {
+  >(expectedType: ExpectedType): expectedType is ExpectedType & OpenapiSchemaBody {
     return isObject(expectedType)
   }
 

--- a/src/server/params.ts
+++ b/src/server/params.ts
@@ -683,6 +683,7 @@ export interface ExtractParamsOpts {
 
 export interface OpenAPIDreamModelRequestBodyModifications<OnlyArray, IncludingArray>
   extends ParamsForOptsBase<OnlyArray> {
+  params?: OnlyArray
   combining?: OpenapiSchemaPropertiesShorthand
   including?: IncludingArray
 }

--- a/src/server/params.ts
+++ b/src/server/params.ts
@@ -2,12 +2,14 @@ import { CalendarDate, ClockTime, ClockTimeTz, DateTime, Dream } from '@rvoh/dre
 import {
   OpenapiSchemaArray,
   OpenapiSchemaBody,
+  OpenapiSchemaBodyShorthand,
   OpenapiSchemaInteger,
   OpenapiSchemaNumber,
   OpenapiSchemaObjectBase,
   OpenapiSchemaPrimitiveGeneric,
   OpenapiSchemaPropertiesShorthand,
   OpenapiSchemaString,
+  OpenapiShorthandPrimitiveTypes,
 } from '@rvoh/dream/openapi'
 import {
   DreamAttributes,
@@ -29,6 +31,7 @@ import isObject from '../helpers/isObject.js'
 import isUuid from '../helpers/isUuid.js'
 import { validateObject } from '../helpers/validateOpenApiSchema.js'
 import { Inc } from '../i18n/conf/types.js'
+import type { VirtualAttributeStatement } from '../openapi-renderer/helpers/dreamColumnOpenapiShape.js'
 import paramNamesForDreamClass from './helpers/paramNamesForDreamClass.js'
 
 export default class Params {
@@ -120,7 +123,13 @@ export default class Params {
             { allowNull: columnMetadata.allowNull },
           )
         } else if (dreamClass.isVirtualColumn(columnName)) {
-          returnObj[columnName as keyof typeof returnObj] = params[columnName as keyof typeof params]
+          const virtualCast = virtualAttributeCast(dreamClass, columnName)
+          returnObj[columnName as keyof typeof returnObj] = this.cast(
+            params,
+            columnName.toString(),
+            virtualCast.expectedType,
+            { allowNull: virtualCast.allowNull },
+          )
         } else if (columnMetadata?.enumValues) {
           const paramValue = params[columnName as keyof typeof params]
 
@@ -282,14 +291,16 @@ export default class Params {
 
     if (paramValue === null || paramValue === undefined) {
       if (expectedType === 'null') return null as ReturnType
-      if (!this.shouldUseOpenapiValidation(expectedType)) {
-        this.throwUnlessAllowNull(
-          paramName,
-          paramValue,
-          typeToError(expectedType as PsychicParamsPrimitiveLiteral),
-          opts,
-        )
+      if (this.shouldUseOpenapiValidation(expectedType)) {
+        return paramValue as ReturnType
       }
+
+      this.throwUnlessAllowNull(
+        paramName,
+        paramValue,
+        typeToError(expectedType as PsychicParamsPrimitiveLiteral),
+        opts,
+      )
 
       return paramValue as ReturnType
     }
@@ -434,15 +445,7 @@ export default class Params {
 
       default:
         if (this.shouldUseOpenapiValidation(expectedType)) {
-          const res = validateObject(paramValue, expectedType, { coerceTypes: true })
-          if (res.isValid) {
-            return res.data as ReturnType
-          } else {
-            throw new ParamValidationError(
-              paramName,
-              res.errors?.map(err => err.message) || ['openapi validation failed'],
-            )
-          }
+          return this.validateOpenapiOrThrow(paramName, paramValue, expectedType) as ReturnType
         }
 
         // TODO: serialize/sanitize before printing, handle array types
@@ -456,6 +459,20 @@ export default class Params {
     ExpectedType extends PsychicParamsPrimitiveLiteral | RegExp | OpenapiSchemaBody,
   >(expectedType: ExpectedType): boolean {
     return isObject(expectedType)
+  }
+
+  private validateOpenapiOrThrow(
+    paramName: string,
+    paramValue: PsychicParamsPrimitive | PsychicParamsDictionary | PsychicParamsDictionary[],
+    expectedType: OpenapiSchemaBody,
+  ) {
+    const res = validateObject(paramValue, expectedType, { coerceTypes: true })
+    if (res.isValid) return res.data
+
+    throw new ParamValidationError(
+      paramName,
+      res.errors?.map(err => err.message) || ['openapi validation failed'],
+    )
   }
 
   public restrict(allowed: string[]) {
@@ -723,6 +740,141 @@ const DB_TYPE_TO_CAST_TYPE: Record<string, PsychicParamsPrimitiveLiteral> = {
   numeric: 'number',
   'numeric[]': 'number[]',
 }
+
+function virtualAttributeCast(
+  dreamClass: typeof Dream,
+  columnName: string,
+): {
+  expectedType: PsychicParamsPrimitiveLiteral
+  allowNull: boolean
+} {
+  const metadata = (dreamClass['virtualAttributes'] as VirtualAttributeStatement[]).find(
+    statement => statement.property === columnName,
+  )
+
+  const primitiveCast = primitiveCastFromOpenapi(metadata?.type)
+  if (!primitiveCast) throw new Error(`Unable to infer params cast type for virtual column: ${columnName}`)
+  return primitiveCast
+}
+
+function primitiveCastFromOpenapi(
+  openapi: OpenapiShorthandPrimitiveTypes | OpenapiSchemaBodyShorthand | undefined,
+): { expectedType: PsychicParamsPrimitiveLiteral; allowNull: boolean } | null {
+  if (!openapi) return null
+
+  if (Array.isArray(openapi)) {
+    const nonNullOpenapi = openapi.find(type => type !== 'null')
+    const primitiveCast = primitiveCastFromOpenapi(
+      nonNullOpenapi as OpenapiShorthandPrimitiveTypes | OpenapiSchemaBodyShorthand | undefined,
+    )
+    if (!primitiveCast) return null
+    return { ...primitiveCast, allowNull: true }
+  }
+
+  if (typeof openapi === 'string') {
+    const expectedType = shorthandToCastType(openapi)
+    return expectedType ? { expectedType, allowNull: false } : null
+  }
+
+  if (!('type' in openapi)) return null
+
+  const openapiType = openapi.type
+  const allowNull = Array.isArray(openapiType) && openapiType.includes('null')
+  const nonNullType = Array.isArray(openapiType) ? openapiType.find(type => type !== 'null') : openapiType
+
+  if (nonNullType === 'array') {
+    if (!('items' in openapi)) return null
+    const item = openapi.items
+    const itemType = item && 'type' in item ? item.type : undefined
+    const itemFormat = item && 'format' in item ? item.format : undefined
+    if (Array.isArray(itemType)) return null
+    const itemCastType = openapiTypeToCastType(itemType, itemFormat)
+    if (!itemCastType) return null
+    return { expectedType: `${itemCastType}[]` as PsychicParamsPrimitiveLiteral, allowNull }
+  }
+
+  const expectedType = openapiTypeToCastType(nonNullType, 'format' in openapi ? openapi.format : undefined)
+  return expectedType ? { expectedType, allowNull } : null
+}
+
+function shorthandToCastType(openapi: string): PsychicParamsPrimitiveLiteral | null {
+  switch (openapi) {
+    case 'date-time':
+      return 'datetime'
+    case 'date-time[]':
+      return 'datetime[]'
+    case 'decimal':
+      return 'number'
+    case 'decimal[]':
+      return 'number[]'
+    case 'json':
+      return 'json'
+    case 'null':
+      return 'null'
+    default:
+      return PARAM_CAST_TYPES.includes(openapi as PsychicParamsPrimitiveLiteral)
+        ? (openapi as PsychicParamsPrimitiveLiteral)
+        : null
+  }
+}
+
+function openapiTypeToCastType(
+  openapiType: string | undefined,
+  format: string | undefined,
+): PsychicParamsPrimitiveLiteral | null {
+  switch (openapiType) {
+    case 'boolean':
+      return 'boolean'
+    case 'integer':
+      return 'integer'
+    case 'number':
+      return 'number'
+    case 'null':
+      return 'null'
+    case 'object':
+      return 'json'
+    case 'string':
+      switch (format) {
+        case 'date':
+          return 'date'
+        case 'date-time':
+          return 'datetime'
+        case 'uuid':
+          return 'uuid'
+        default:
+          return 'string'
+      }
+    default:
+      return null
+  }
+}
+
+const PARAM_CAST_TYPES: PsychicParamsPrimitiveLiteral[] = [
+  'bigint',
+  'bigint[]',
+  'boolean',
+  'boolean[]',
+  'date',
+  'date[]',
+  'datetime',
+  'datetime[]',
+  'integer',
+  'integer[]',
+  'json',
+  'json[]',
+  'null',
+  'null[]',
+  'number',
+  'number[]',
+  'string',
+  'string[]',
+  'time',
+  'time[]',
+  'timetz',
+  'timetz[]',
+  'uuid',
+  'uuid[]',
+]
 
 const typeToErrorMap: Record<PsychicParamsPrimitiveLiteral, string> = {
   bigint: 'expected bigint',

--- a/test-app/src/app/models/User.ts
+++ b/test-app/src/app/models/User.ts
@@ -99,6 +99,9 @@ export default class User extends ApplicationModel {
   @deco.Virtual('string[]')
   public openapiVirtualSpecTest2: string | null | undefined
 
+  @deco.Encrypted()
+  public secret: DreamColumn<User, 'encryptedSecret'>
+
   public openapiVirtualSpecTest3: string | null | undefined
 
   @deco.HasMany('Balloon')

--- a/test-app/src/db/migrations/000000001-create-users.ts
+++ b/test-app/src/db/migrations/000000001-create-users.ts
@@ -59,6 +59,7 @@ export async function up(db: Kysely<any>): Promise<void> {
     .addColumn('required_jsonb_data', 'jsonb', col => col.notNull().defaultTo('{}'))
     .addColumn('json_data', 'json')
     .addColumn('required_json_data', 'json', col => col.notNull().defaultTo('{}'))
+    .addColumn('encrypted_secret', 'text')
     .addColumn('password_digest', 'varchar', col => col.notNull())
 
     .addColumn('collar_count', 'bigint')

--- a/test-app/src/openapi/openapi.json
+++ b/test-app/src/openapi/openapi.json
@@ -496,6 +496,12 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "secret": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
@@ -923,6 +929,12 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "secret": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
@@ -4061,6 +4073,12 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "secret": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
@@ -4582,6 +4600,12 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "secret": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
@@ -5312,6 +5336,12 @@
                       "type": "string"
                     }
                   },
+                  "secret": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
                   "cursor": {
                     "type": [
                       "string",
@@ -5850,6 +5880,12 @@
                       "type": "string"
                     }
                   },
+                  "secret": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
                   "page": {
                     "type": "integer",
                     "description": "Page number"
@@ -6387,6 +6423,12 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "secret": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "cursor": {
                     "type": [

--- a/test-app/src/types/db.ts
+++ b/test-app/src/types/db.ts
@@ -214,6 +214,7 @@ export interface Users {
   createdAt: Generated<Timestamp>
   createdOn: Generated<Timestamp>
   email: string
+  encryptedSecret: string | null
   favoriteBigint: Int8 | null
   favoriteBigints: ArrayType<Int8> | null
   favoriteBooleans: boolean[] | null

--- a/test-app/src/types/dream.ts
+++ b/test-app/src/types/dream.ts
@@ -871,6 +871,7 @@ export const schema = {
       'createdAt',
       'createdOn',
       'email',
+      'encryptedSecret',
       'favoriteBigint',
       'favoriteBigints',
       'favoriteBooleans',
@@ -990,6 +991,15 @@ export const schema = {
         enumValues: null,
         dbType: 'character varying',
         allowNull: false,
+        isArray: false,
+      },
+      encryptedSecret: {
+        coercedType: {} as string | null,
+        enumType: null,
+        enumArrayType: null,
+        enumValues: null,
+        dbType: 'text',
+        allowNull: true,
         isArray: false,
       },
       favoriteBigint: {
@@ -1411,6 +1421,7 @@ export const schema = {
       'openapiVirtualSpecTest',
       'openapiVirtualSpecTest2',
       'password',
+      'secret',
     ],
     associations: {
       balloons: {

--- a/test-app/src/types/openapi/openapi.d.ts
+++ b/test-app/src/types/openapi/openapi.d.ts
@@ -186,6 +186,7 @@ export interface paths {
                         password?: string | null;
                         openapiVirtualSpecTest?: string | null;
                         openapiVirtualSpecTest2?: string[];
+                        secret?: string | null;
                     };
                 };
             };
@@ -307,6 +308,7 @@ export interface paths {
                         password?: string | null;
                         openapiVirtualSpecTest?: string | null;
                         openapiVirtualSpecTest2?: string[];
+                        secret?: string | null;
                     };
                 };
             };
@@ -2507,6 +2509,7 @@ export interface paths {
                         password?: string | null;
                         openapiVirtualSpecTest?: string | null;
                         openapiVirtualSpecTest2?: string[];
+                        secret?: string | null;
                     };
                 };
             };
@@ -2703,6 +2706,7 @@ export interface paths {
                         password?: string | null;
                         openapiVirtualSpecTest?: string | null;
                         openapiVirtualSpecTest2?: string[];
+                        secret?: string | null;
                     };
                 };
             };
@@ -3033,6 +3037,7 @@ export interface paths {
                         password?: string | null;
                         openapiVirtualSpecTest?: string | null;
                         openapiVirtualSpecTest2?: string[];
+                        secret?: string | null;
                         /** @description Pagination cursor */
                         cursor?: string | null;
                     };
@@ -3219,6 +3224,7 @@ export interface paths {
                         password?: string | null;
                         openapiVirtualSpecTest?: string | null;
                         openapiVirtualSpecTest2?: string[];
+                        secret?: string | null;
                         /** @description Page number */
                         page?: number;
                     };
@@ -3405,6 +3411,7 @@ export interface paths {
                         password?: string | null;
                         openapiVirtualSpecTest?: string | null;
                         openapiVirtualSpecTest2?: string[];
+                        secret?: string | null;
                         /** @description Pagination cursor */
                         cursor?: string | null;
                     };


### PR DESCRIPTION
## Summary
- Cast Dream virtual params, including @Encrypted-backed fields, using their declared OpenAPI metadata instead of passing values through unchecked.
- Reuse Psychic's existing Params.cast primitives for the supported OpenAPI subset, including nullable and array shapes.
- Bump @rvoh/psychic to 3.7.1 and document the behavior change.

## Verification
- pnpm lint
- pnpm build:test-app
- pnpm uspec