### PR TITLE
fix: improve controller-hierarchy error message and document optional-auth pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.1
+
+- `psy check:controller-hierarchy` violation messages now include a remediation tip pointing to the child controller's directory, suggesting the optional-auth-at-namespace-base pattern: create a `BaseController` at the same level as the violating controller and use `requireCurrentUser()` in controllers that need it. The `unauthorized()` JSDoc is also expanded with an example of this pattern.
+
 ## 3.8.0
 
 - `Params.for` and `PsychicController#extractParams` now cast and validate Dream virtual columns, including `@Encrypted` fields, from their declared OpenAPI metadata instead of passing them through unchecked. This makes virtual param handling match concrete Dream columns: `@Virtual(['string', 'null'])` and nullable `@Encrypted` params reject non-strings while allowing `null`, and virtual array shorthands such as `string[]` are cast through the same array path used for database-backed array columns.

--- a/spec/unit/bin/helpers/printControllerHierarchy.spec.ts
+++ b/spec/unit/bin/helpers/printControllerHierarchy.spec.ts
@@ -114,7 +114,7 @@ describe('printControllerHierarchy', () => {
         controllersPath,
       )
       expect(result).toEqual(
-        '[hierarchy violation: src/app/controllers/Api/V1/UsersController.ts should extend a BaseController at its same level]',
+        '[hierarchy violation: src/app/controllers/Api/V1/UsersController.ts should extend a BaseController at its same level]\n  Tip: create a BaseController in src/app/controllers/Api/V1/ that extends the appropriate parent, then use requireCurrentUser() in controllers that require a user.',
       )
     })
 
@@ -125,7 +125,7 @@ describe('printControllerHierarchy', () => {
         controllersPath,
       )
       expect(result).toEqual(
-        '[hierarchy violation: src/app/controllers/Internal/Candidates/CitiesController.ts should extend a BaseController at its same level]',
+        '[hierarchy violation: src/app/controllers/Internal/Candidates/CitiesController.ts should extend a BaseController at its same level]\n  Tip: create a BaseController in src/app/controllers/Internal/Candidates/ that extends the appropriate parent, then use requireCurrentUser() in controllers that require a user.',
       )
     })
   })
@@ -241,7 +241,7 @@ describe('printControllerHierarchy', () => {
       // Api/V1/UsersController extends ApplicationController (root dir), but lives in Api/V1/
       // That skips the Api/ directory level, so it should have a violation
       const expectedViolation = colors.yellow(
-        '[hierarchy violation: test-app/src/app/controllers/Api/V1/UsersController.ts should extend a BaseController at its same level]',
+        '[hierarchy violation: test-app/src/app/controllers/Api/V1/UsersController.ts should extend a BaseController at its same level]\n  Tip: create a BaseController in test-app/src/app/controllers/Api/V1/ that extends the appropriate parent, then use requireCurrentUser() in controllers that require a user.',
       )
       const violationLine = lines.find(l => l.includes(expectedViolation))
       expect(violationLine).toBeDefined()
@@ -263,7 +263,7 @@ describe('printControllerHierarchy', () => {
       const lines = controllerHierarchyLines()
 
       const expectedViolation = colors.yellow(
-        '[hierarchy violation: test-app/src/app/controllers/Api/V1/UsersController.ts should extend a BaseController at its same level]',
+        '[hierarchy violation: test-app/src/app/controllers/Api/V1/UsersController.ts should extend a BaseController at its same level]\n  Tip: create a BaseController in test-app/src/app/controllers/Api/V1/ that extends the appropriate parent, then use requireCurrentUser() in controllers that require a user.',
       )
       const violationIdx = lines.findIndex(l => l.includes(expectedViolation))
       expect(violationIdx).toBeGreaterThan(-1)
@@ -291,7 +291,7 @@ describe('printControllerHierarchy', () => {
       // Api/V1/UsersController extends ApplicationController but is two directories deep
       const v1Violation = violations.find(v => v.includes('Api/V1/UsersController.ts'))
       expect(v1Violation).toEqual(
-        '[hierarchy violation: test-app/src/app/controllers/Api/V1/UsersController.ts should extend a BaseController at its same level]',
+        '[hierarchy violation: test-app/src/app/controllers/Api/V1/UsersController.ts should extend a BaseController at its same level]\n  Tip: create a BaseController in test-app/src/app/controllers/Api/V1/ that extends the appropriate parent, then use requireCurrentUser() in controllers that require a user.',
       )
     })
 

--- a/src/bin/helpers/printControllerHierarchy.ts
+++ b/src/bin/helpers/printControllerHierarchy.ts
@@ -178,7 +178,8 @@ export function hierarchyViolation(
   }
 
   const childFilePath = controllersPath + '/' + childGlobalName.replace(/^controllers\//, '') + '.ts'
-  return `[hierarchy violation: ${childFilePath} should extend a BaseController at its same level]`
+  const childDirPath = controllersPath + '/' + childDir.replace(/^controllers\//, '')
+  return `[hierarchy violation: ${childFilePath} should extend a BaseController at its same level]\n  Tip: create a BaseController in ${childDirPath} that extends the appropriate parent, then use requireCurrentUser() in controllers that require a user.`
 }
 
 function collectTreeLines(

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -1222,6 +1222,38 @@ export default class PsychicController {
    * @param message - Optional error message to include in the response
    * @throws {HttpStatusUnauthorized} Always throws this error
    *
+   * **Optional-auth pattern (public endpoints with personalized fields)**
+   *
+   * When a namespace has a mix of public and protected routes, put the optional
+   * auth logic in the namespace-level base controller and enforce it in child
+   * controllers that require a user. This avoids cross-namespace inheritance and
+   * keeps `psy check:controller-hierarchy` happy.
+   *
+   * ```ts
+   * // V1/BaseController — loads the user if a session exists, but does not require one.
+   * // Public routes (e.g. ListingsController#index) extend this and return personalized
+   * // data when currentUser is present, or anonymous data when it is not.
+   * class V1BaseController extends ApplicationController {
+   *   protected currentUser: User | null = null
+   *
+   *   @BeforeAction()
+   *   public async loadCurrentUser() {
+   *     this.currentUser = await User.find(this.session.get('userId'))
+   *   }
+   * }
+   *
+   * // V1/HostBaseController — extends V1BaseController and requires the user.
+   * // All host-management routes extend this instead of V1BaseController.
+   * class V1HostBaseController extends V1BaseController {
+   *   protected currentUser!: User // narrowed: never null past this point
+   *
+   *   @BeforeAction()
+   *   public requireCurrentUser() {
+   *     if (!this.currentUser) this.unauthorized()
+   *   }
+   * }
+   * ```
+   *
    * @example
    * ```ts
    * class UsersController extends ApplicationController {


### PR DESCRIPTION
## Summary

- `psy check:controller-hierarchy` violation messages now append a remediation tip: "create a BaseController in `<child-namespace>/` that extends the appropriate parent, then use `requireCurrentUser()` in controllers that require a user." Previously the message identified the violation but left the developer to figure out the fix.
- `PsychicController#unauthorized()` JSDoc gains an example of the optional-auth-at-namespace-base pattern — a namespace `BaseController` that optionally loads the current user via `@BeforeAction`, plus a child `HostBaseController` that narrows the type and enforces auth with `requireCurrentUser()`. This is the correct architecture for namespaces that mix public and protected routes.

## Test plan

- [ ] All `printControllerHierarchy` specs (38) pass — verified locally
- [ ] `pnpm build:test-app` passes — verified locally
- [ ] `pnpm lint` passes — verified locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZPhwk2ywX6WuYZtaQpMms