### PR TITLE
Fix default OpenAPI validation responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.1
+
+- OpenAPI generation no longer advertises `422` ValidationErrors as a default response on every endpoint. Psychic's automatic validation rescue paths for Dream validation errors, OpenAPI request validation failures, and param validation errors return `400` by design; `422` remains available only when an endpoint explicitly raises it, such as through `unprocessableContent(...)`.
+
 ## 3.8.0
 
 - `Params.for` and `PsychicController#extractParams` now cast and validate Dream virtual columns, including `@Encrypted` fields, from their declared OpenAPI metadata instead of passing them through unchecked. This makes virtual param handling match concrete Dream columns: `@Virtual(['string', 'null'])` and nullable `@Encrypted` params reject non-strings while allowing `null`, and virtual array shorthands such as `string[]` are cast through the same array path used for database-backed array columns.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "author": "RVOHealth",
   "repository": {
     "type": "git",

--- a/spec/unit/openapi-renderer/app/buildOpenapiObject.spec.ts
+++ b/spec/unit/openapi-renderer/app/buildOpenapiObject.spec.ts
@@ -777,7 +777,6 @@ describe('OpenapiAppRenderer', () => {
               '403': { $ref: '#/components/responses/Forbidden' },
               '404': { $ref: '#/components/responses/NotFound' },
               '409': { $ref: '#/components/responses/Conflict' },
-              '422': { $ref: '#/components/responses/ValidationErrors' },
               '490': { $ref: '#/components/responses/CustomAdminResponse' },
               '500': { $ref: '#/components/responses/InternalServerError' },
             },

--- a/spec/unit/openapi-renderer/endpoint/toPathObject.spec.ts
+++ b/spec/unit/openapi-renderer/endpoint/toPathObject.spec.ts
@@ -2306,11 +2306,9 @@ describe('OpenapiEndpointRenderer', () => {
               400: {
                 $ref: '#/components/responses/BadRequest',
               },
-              422: {
-                $ref: '#/components/responses/ValidationErrors',
-              },
             }),
           )
+          expect(response['/users/howyadoin']!.get.responses).not.toHaveProperty('422')
         })
       })
 
@@ -2351,6 +2349,25 @@ describe('OpenapiEndpointRenderer', () => {
                     },
                   },
                 },
+              },
+            }),
+          )
+        })
+
+        it('endpoint-level 422 responses are still rendered when explicitly specified', () => {
+          const renderer = new OpenapiEndpointRenderer(User, UsersController, 'howyadoin', {
+            responses: {
+              422: {
+                description: 'Validation errors intended for display',
+              },
+            },
+          })
+
+          const response = renderer.toPathObject(routes, defaultToPathObjectOpts()).openapi
+          expect(response['/users/howyadoin']!.get.responses).toEqual(
+            expect.objectContaining({
+              422: {
+                description: 'Validation errors intended for display',
               },
             }),
           )

--- a/src/openapi-renderer/defaults.ts
+++ b/src/openapi-renderer/defaults.ts
@@ -20,9 +20,6 @@ export const DEFAULT_OPENAPI_RESPONSES = {
   409: {
     $ref: '#/components/responses/Conflict',
   },
-  422: {
-    $ref: '#/components/responses/ValidationErrors',
-  },
   500: {
     $ref: '#/components/responses/InternalServerError',
   },

--- a/test-app/src/openapi/admin.openapi.json
+++ b/test-app/src/openapi/admin.openapi.json
@@ -39,9 +39,6 @@
           "409": {
             "$ref": "#/components/responses/Conflict"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomAdminResponse"
           },
@@ -84,9 +81,6 @@
           "409": {
             "$ref": "#/components/responses/Conflict"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomAdminResponse"
           },
@@ -128,9 +122,6 @@
           },
           "409": {
             "$ref": "#/components/responses/Conflict"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomAdminResponse"
@@ -189,9 +180,6 @@
           "409": {
             "$ref": "#/components/responses/Conflict"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomAdminResponse"
           },
@@ -233,9 +221,6 @@
           },
           "409": {
             "$ref": "#/components/responses/Conflict"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomAdminResponse"
@@ -332,9 +317,6 @@
           },
           "409": {
             "$ref": "#/components/responses/Conflict"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomAdminResponse"

--- a/test-app/src/openapi/mobile.openapi.json
+++ b/test-app/src/openapi/mobile.openapi.json
@@ -29,9 +29,6 @@
           "409": {
             "$ref": "#/components/responses/Conflict"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
           }
@@ -60,9 +57,6 @@
           },
           "409": {
             "$ref": "#/components/responses/Conflict"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -108,9 +102,6 @@
           "409": {
             "$ref": "#/components/responses/Conflict"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
           }
@@ -139,9 +130,6 @@
           },
           "409": {
             "$ref": "#/components/responses/Conflict"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -225,9 +213,6 @@
           },
           "409": {
             "$ref": "#/components/responses/Conflict"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"

--- a/test-app/src/openapi/openapi.json
+++ b/test-app/src/openapi/openapi.json
@@ -49,9 +49,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -105,9 +102,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -530,9 +524,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -964,9 +955,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -1028,9 +1016,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -1098,9 +1083,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -1192,9 +1174,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -1259,9 +1238,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -1330,9 +1306,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -1426,9 +1399,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -1519,9 +1489,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -1580,9 +1547,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -1643,9 +1607,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -1697,9 +1658,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -1767,9 +1725,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -1830,9 +1785,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -1884,9 +1836,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -1962,9 +1911,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -2024,9 +1970,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -2072,9 +2015,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -2135,9 +2075,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -2196,9 +2133,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -2262,9 +2196,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -2452,9 +2383,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -2629,9 +2557,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -2702,9 +2627,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -2800,9 +2722,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -2868,9 +2787,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -2932,9 +2848,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -2989,9 +2902,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -3074,9 +2984,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -3143,9 +3050,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -3205,9 +3109,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -3259,9 +3160,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -3342,9 +3240,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -3408,9 +3303,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -3462,9 +3354,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -3518,9 +3407,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -3572,9 +3458,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -3628,9 +3511,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -3682,9 +3562,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -4114,9 +3991,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -4158,9 +4032,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -4222,9 +4093,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -4635,9 +4503,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -4669,9 +4534,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -4733,9 +4595,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -4796,9 +4655,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -4858,9 +4714,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -4944,9 +4797,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -5401,9 +5251,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -5488,9 +5335,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -5947,9 +5791,6 @@
           "418": {
             "$ref": "#/components/responses/CustomResponse"
           },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
-          },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
           },
@@ -6032,9 +5873,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"
@@ -6488,9 +6326,6 @@
           },
           "418": {
             "$ref": "#/components/responses/CustomResponse"
-          },
-          "422": {
-            "$ref": "#/components/responses/ValidationErrors"
           },
           "490": {
             "$ref": "#/components/responses/CustomResponse"

--- a/test-app/src/types/openapi/openapi.d.ts
+++ b/test-app/src/types/openapi/openapi.d.ts
@@ -38,7 +38,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -89,7 +88,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -199,7 +197,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -321,7 +318,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -365,7 +361,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -419,7 +414,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -478,7 +472,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -528,7 +521,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -578,7 +570,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -639,7 +630,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -698,7 +688,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -754,7 +743,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -808,7 +796,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -856,7 +843,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -914,7 +900,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -963,7 +948,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -1011,7 +995,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -1071,7 +1054,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -1127,7 +1109,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -1168,7 +1149,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -1222,7 +1202,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -1276,7 +1255,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -1332,7 +1310,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -1445,7 +1422,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -1526,7 +1502,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -1575,7 +1550,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -1639,7 +1613,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -1697,7 +1670,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -1751,7 +1723,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -1800,7 +1771,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -1859,7 +1829,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -1909,7 +1878,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -1965,7 +1933,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -2015,7 +1982,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -2072,7 +2038,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -2125,7 +2090,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -2175,7 +2139,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -2225,7 +2188,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -2275,7 +2237,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -2325,7 +2286,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -2375,7 +2335,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -2425,7 +2384,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -2529,7 +2487,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -2583,7 +2540,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -2618,7 +2574,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -2719,7 +2674,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -2767,7 +2721,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -2821,7 +2774,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -2875,7 +2827,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -2934,7 +2885,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -3062,7 +3012,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -3121,7 +3070,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -3251,7 +3199,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -3308,7 +3255,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };
@@ -3436,7 +3382,6 @@ export interface paths {
                 404: components["responses"]["NotFound"];
                 409: components["responses"]["Conflict"];
                 418: components["responses"]["CustomResponse"];
-                422: components["responses"]["ValidationErrors"];
                 490: components["responses"]["CustomResponse"];
                 500: components["responses"]["InternalServerError"];
             };


### PR DESCRIPTION
## Summary
- remove the default generated 422 ValidationErrors response from OpenAPI endpoints
- keep explicit 422 support intact while matching Psychic's automatic validation behavior, which returns 400
- bump package version to 3.8.1 and add a changelog entry

## Tests
- pnpm uspec spec/unit/openapi-renderer/endpoint/toPathObject.spec.ts spec/unit/openapi-renderer/app/buildOpenapiObject.spec.ts spec/unit/scenarios/openapi/validation/requestBody.spec.ts spec/unit/scenarios/openapi/validation/query.spec.ts spec/unit/scenarios/openapi/validation/headers.spec.ts spec/unit/scenarios/saving-records.spec.ts spec/unit/scenarios/params/casting.spec.ts spec/unit/scenarios/response-statuses/422-unprocessable-content.spec.ts