### PR TITLE
Bump patch version for GitHub npm publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.9.0
+## 3.8.2
 
 - switch to Github action publishing to npmjs.com
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.9.0
+
+- switch to Github action publishing to npmjs.com
+
 ## 3.8.1
 
 - OpenAPI generation no longer advertises `422` ValidationErrors as a default response on every endpoint. Psychic's automatic validation rescue paths for Dream validation errors, OpenAPI request validation failures, and param validation errors return `400` by design; `422` remains available only when an endpoint explicitly raises it, such as through `unprocessableContent(...)`.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.9.0",
+  "version": "3.8.2",
   "author": "RVOHealth",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "author": "RVOHealth",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Bumps the package minor version for GitHub releases and signed provenance when publishing to npmjs.com.