### PR TITLE
fix: upgrade to pnpm 11.9.0, deny build scripts in workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.3
+
+- upgrade to pnpm@11.9.0; add strictDepBuilds: false and deny esbuild/puppeteer build scripts in pnpm-workspace.yaml
+
 ## 3.8.2
 
 - switch to Github action publishing to npmjs.com

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "author": "RVOHealth",
   "publishConfig": {
     "access": "public"
@@ -137,5 +137,5 @@
     "vitest": "^4.1.0",
     "winston": "^3.14.2"
   },
-  "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d"
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,14 +2,15 @@ overrides:
   diff: '>=8.0.3'
   path-to-regexp: '>=8.4.0'
 
+strictDepBuilds: false
 # SECURITY — allowBuilds is a supply-chain allowlist. pnpm 10+ blocks ALL
 # dependency lifecycle scripts (postinstall, etc.) by default; that default is
 # the primary defense against Shai-Hulud-class npm worms. Only packages listed
 # below (= true) may run install/build scripts. Keep this MINIMAL — every entry
 # re-opens script execution for that package, so add one only with clear cause.
 allowBuilds:
-  esbuild: true
-  puppeteer: true
+  esbuild: false
+  puppeteer: false
 
 minimumReleaseAgeExclude:
   - '@rvoh/dream-spec-helpers@2.2.0'


### PR DESCRIPTION
## Summary

- Upgrades `packageManager` to `pnpm@11.9.0`
- Adds `strictDepBuilds: false` to `pnpm-workspace.yaml` to suppress pnpm 11's hard-error when build-script deps aren't explicitly declared
- Flips `esbuild` and `puppeteer` in `allowBuilds` from `true` to `false` — both ship prebuilt binaries via optional deps and don't need postinstall scripts; Puppeteer's browser is installed via an explicit `pnpm puppeteer browsers install firefox` CI step, not postinstall
- Bumps version to `3.8.3`

## Test plan

- [ ] CI passes on this branch
- [ ] `pnpm install` completes without `ERR_PNPM_IGNORED_BUILDS` errors
- [ ] Puppeteer browser install step in CI still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhY4PpeeQcHTxS2kZr1n8x