### PR TITLE
Trim string array params before validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,15 @@
 
 This file provides instructions for AI agents working on this project.
 
+## Release Requirements
+
+For any public-facing functionality change, bug fix, behavior change, API change, CLI change, generated output change, or documentation-affecting framework change, update both:
+
+- `package.json` version
+- `CHANGELOG.md`
+
+Do this before opening a PR.
+
 ## Database Commands
 
 ### Migrate the Database

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.4
+
+- String array params now trim each string element before validation/casting, matching scalar string params. This fixes enum-backed string arrays in `castParam`, `extractParams`, and `Params.for` rejecting otherwise-valid values with leading or trailing whitespace.
+
 ## 3.8.3
 
 - upgrade to pnpm@11.9.0; add strictDepBuilds: false and deny esbuild/puppeteer build scripts in pnpm-workspace.yaml

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "author": "RVOHealth",
   "publishConfig": {
     "access": "public"

--- a/spec/unit/server/params.spec.ts
+++ b/spec/unit/server/params.spec.ts
@@ -182,6 +182,12 @@ describe('Params', () => {
 
           expect(error!.errors).toEqual({ favoriteTreats: ['did not match expected enum values'] })
         })
+
+        it('trims enum values before validating', () => {
+          expect(Params.for({ favoriteTreats: ['  efishy feesh  ', '\nsnick snowcks\t'] }, Pet)).toEqual({
+            favoriteTreats: ['efishy feesh', 'snick snowcks'],
+          })
+        })
       })
     })
 
@@ -1378,6 +1384,19 @@ describe('Params', () => {
                   }),
                 ).toThrow(ParamValidationError)
               })
+            })
+          })
+
+          context('with enum passed', () => {
+            it('trims values before validating against the enum', () => {
+              const result: TestEnum[] = Params.cast(
+                { howyadoin: ['  hello  ', '\nworld\t'] },
+                'howyadoin',
+                'string[]',
+                { enum: TestEnumValues },
+              )
+
+              expect(result).toEqual(['hello', 'world'])
             })
           })
         })

--- a/src/server/params.ts
+++ b/src/server/params.ts
@@ -285,6 +285,8 @@ export default class Params {
     expectedType: ExpectedType,
     opts?: OptsType,
   ): AllowNullOrUndefined extends true ? ValidatedType | null | undefined : ValidatedType {
+    if (typeof paramValue === 'string') paramValue = paramValue.trim()
+
     if (expectedType instanceof RegExp) {
       return this.matchRegexOrThrow(paramName, paramValue as string, expectedType) as ReturnType
     }


### PR DESCRIPTION
## Summary
- Trim string param values in the instance Params#cast path so array elements are normalized consistently with scalar params
- Add regression coverage for string[] enum casts and database enum array extraction
- Bump package version to 3.8.4 and add CHANGELOG entry
- Add the release-requirements rule to AGENTS.md while keeping CLAUDE.md as the repo-standard pointer to AGENTS.md

## Tests
- pnpm uspec spec/unit/server/params.spec.ts
- pnpm build:test-app