### PR TITLE
Prefer 400 for validation error payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.5
+
+- Remove the default `ValidationErrors` OpenAPI response component and document `400` as the preferred status for deliberate user-facing validation error payloads. Psychic still supports explicit `422` responses and `unprocessableContent(...)`; automatic validation rescue paths continue to return bare `400` responses.
+
 ## 3.8.4
 
 - String array params now trim each string element before validation/casting, matching scalar string params. This fixes enum-backed string arrays in `castParam`, `extractParams`, and `Params.for` rejecting otherwise-valid values with leading or trailing whitespace.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "author": "RVOHealth",
   "publishConfig": {
     "access": "public"

--- a/spec/unit/openapi-renderer/app/buildOpenapiObject.spec.ts
+++ b/spec/unit/openapi-renderer/app/buildOpenapiObject.spec.ts
@@ -696,19 +696,6 @@ describe('OpenapiAppRenderer', () => {
                   'The request failed because a conflict was detected with the given request params',
               },
 
-              // 422
-              ValidationErrors: {
-                description:
-                  'The request failed to process due to validation errors with the provided values',
-                content: {
-                  'application/json': {
-                    schema: {
-                      $ref: '#/components/schemas/ValidationErrors',
-                    },
-                  },
-                },
-              },
-
               // 500
               InternalServerError: {
                 description:

--- a/src/openapi-renderer/defaults.ts
+++ b/src/openapi-renderer/defaults.ts
@@ -110,18 +110,6 @@ export const DEFAULT_OPENAPI_COMPONENT_RESPONSES = {
     description: 'The request failed because a conflict was detected with the given request params',
   },
 
-  // 422
-  ValidationErrors: {
-    description: 'The request failed to process due to validation errors with the provided values',
-    content: {
-      'application/json': {
-        schema: {
-          $ref: '#/components/schemas/ValidationErrors',
-        },
-      },
-    },
-  },
-
   // 500
   InternalServerError: {
     description:

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -385,16 +385,14 @@ suggested fix:  "${convertRouteParams(path)}"
 
   /**
    * Automatically rescue certain errors and convert them into status codes.
-   * Validation errors (OpenAPI or otherwise) are by default converted to
-   * 400. 422 MUST ONLY be returned when accompanied by a ValidationErrors
-   * payload (even if the errors object is empty) that is intended to be displayed
-   * to the end user to indicate fields that must be corrected to be
-   * accepted.
+   * Validation errors (OpenAPI or otherwise) are converted to 400. When a
+   * controller deliberately returns field-level validation details for display
+   * to an end user, prefer a 400 response carrying an errors payload in the
+   * same shape as Dream#errors: { errors: { field: ['message'] } }.
    *
-   * Philosophy: do not return information (even difference between 400 & 422)
-   * unless it is explicitly intended for that information to be used to enable
-   * a front end interface to display information to support user-visible
-   * validation (e.g. an email must be formatted correctly).
+   * Philosophy: do not return information unless it is explicitly intended for
+   * that information to be used by a front-end interface supporting
+   * user-visible validation (e.g. an email must be formatted correctly).
    *
    * By default, do not provide an attacker with any visibility into which layer
    * of the application rejected their request.

--- a/test-app/src/openapi/admin.openapi.json
+++ b/test-app/src/openapi/admin.openapi.json
@@ -355,16 +355,6 @@
       "Conflict": {
         "description": "The request failed because a conflict was detected with the given request params"
       },
-      "ValidationErrors": {
-        "description": "The request failed to process due to validation errors with the provided values",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/ValidationErrors"
-            }
-          }
-        }
-      },
       "InternalServerError": {
         "description": "the server encountered an unexpected condition that prevented it from fulfilling the request"
       },

--- a/test-app/src/openapi/internal.openapi.json
+++ b/test-app/src/openapi/internal.openapi.json
@@ -107,16 +107,6 @@
       "Conflict": {
         "description": "The request failed because a conflict was detected with the given request params"
       },
-      "ValidationErrors": {
-        "description": "The request failed to process due to validation errors with the provided values",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/ValidationErrors"
-            }
-          }
-        }
-      },
       "InternalServerError": {
         "description": "the server encountered an unexpected condition that prevented it from fulfilling the request"
       }

--- a/test-app/src/openapi/mobile.openapi.json
+++ b/test-app/src/openapi/mobile.openapi.json
@@ -403,16 +403,6 @@
       "Conflict": {
         "description": "The request failed because a conflict was detected with the given request params"
       },
-      "ValidationErrors": {
-        "description": "The request failed to process due to validation errors with the provided values",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/ValidationErrors"
-            }
-          }
-        }
-      },
       "InternalServerError": {
         "description": "the server encountered an unexpected condition that prevented it from fulfilling the request"
       }

--- a/test-app/src/openapi/openapi.json
+++ b/test-app/src/openapi/openapi.json
@@ -6364,16 +6364,6 @@
       "Conflict": {
         "description": "The request failed because a conflict was detected with the given request params"
       },
-      "ValidationErrors": {
-        "description": "The request failed to process due to validation errors with the provided values",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/ValidationErrors"
-            }
-          }
-        }
-      },
       "InternalServerError": {
         "description": "the server encountered an unexpected condition that prevented it from fulfilling the request"
       },


### PR DESCRIPTION
## Summary
- update router validation-error guidance to bless deliberate 400-with-errors payloads
- remove the default OpenAPI ValidationErrors response component while keeping explicit 422 support
- regenerate test-app OpenAPI specs and bump @rvoh/psychic to 3.8.5

## Verification
- pnpm lint
- pnpm build:test-app
- pnpm uspec