### PR TITLE
Fix STI serializable OpenAPI responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.6
+
+- Fix hand-written OpenAPI response schemas using `$serializable` with an STI base model so they now emit the same `anyOf` union of child serializers that serializer-derived rendering already produces. Non-STI `$serializable` responses and STI keys that resolve to one shared serializer keep their existing single `$ref` shape.
+
 ## 3.8.5
 
 - Remove the default `ValidationErrors` OpenAPI response component and document `400` as the preferred status for deliberate user-facing validation error payloads. Psychic still supports explicit `422` responses and `unprocessableContent(...)`; automatic validation rescue paths continue to return bare `400` responses.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.8.5",
+  "version": "3.8.6",
   "author": "RVOHealth",
   "publishConfig": {
     "access": "public"

--- a/spec/unit/openapi-renderer/body-segment/parse.spec.ts
+++ b/spec/unit/openapi-renderer/body-segment/parse.spec.ts
@@ -3,7 +3,11 @@ import OpenapiSegmentExpander, {
   OpenapiBodyTarget,
 } from '../../../../src/openapi-renderer/body-segment.js'
 import { OpenapiRenderOpts } from '../../../../src/openapi-renderer/endpoint.js'
+import Balloon from '../../../../test-app/src/app/models/Balloon.js'
 import User from '../../../../test-app/src/app/models/User.js'
+import LatexSerializer from '../../../../test-app/src/app/serializers/Balloon/LatexSerializer.js'
+import MylarSerializer from '../../../../test-app/src/app/serializers/Balloon/MylarSerializer.js'
+import { BalloonSummarySerializer } from '../../../../test-app/src/app/serializers/BalloonSerializer.js'
 import { UserSummarySerializer } from '../../../../test-app/src/app/serializers/UserSerializer.js'
 
 describe('OpenapiBodySegmentRenderer', () => {
@@ -153,6 +157,120 @@ describe('OpenapiBodySegmentRenderer', () => {
           },
         })
         expect(results.referencedSerializers).toEqual([UserSummarySerializer])
+      })
+
+      it('expands an STI base model into refs for each child serializer', () => {
+        const results = subject({
+          type: 'object',
+          properties: {
+            result: {
+              $serializable: Balloon,
+            },
+          },
+        } as OpenapiBodySegment)
+
+        expect(results.openapi).toEqual({
+          type: 'object',
+          properties: {
+            result: {
+              anyOf: [
+                {
+                  $ref: '#/components/schemas/BalloonLatex',
+                },
+                {
+                  $ref: '#/components/schemas/BalloonMylar',
+                },
+              ],
+            },
+          },
+        })
+        expect(results.referencedSerializers).toEqual([LatexSerializer, MylarSerializer])
+      })
+
+      it('expands a many STI base model into refs for each child serializer in the array items', () => {
+        const results = subject({
+          type: 'object',
+          properties: {
+            results: {
+              $serializable: Balloon,
+              many: true,
+            },
+          },
+        } as OpenapiBodySegment)
+
+        expect(results.openapi).toEqual({
+          type: 'object',
+          properties: {
+            results: {
+              type: 'array',
+              items: {
+                anyOf: [
+                  {
+                    $ref: '#/components/schemas/BalloonLatex',
+                  },
+                  {
+                    $ref: '#/components/schemas/BalloonMylar',
+                  },
+                ],
+              },
+            },
+          },
+        })
+        expect(results.referencedSerializers).toEqual([LatexSerializer, MylarSerializer])
+      })
+
+      it('includes null in the STI union when maybeNull is true', () => {
+        const results = subject({
+          type: 'object',
+          properties: {
+            result: {
+              $serializable: Balloon,
+              maybeNull: true,
+            },
+          },
+        } as OpenapiBodySegment)
+
+        expect(results.openapi).toEqual({
+          type: 'object',
+          properties: {
+            result: {
+              anyOf: [
+                {
+                  $ref: '#/components/schemas/BalloonLatex',
+                },
+                {
+                  $ref: '#/components/schemas/BalloonMylar',
+                },
+                {
+                  type: 'null',
+                },
+              ],
+            },
+          },
+        })
+        expect(results.referencedSerializers).toEqual([LatexSerializer, MylarSerializer])
+      })
+
+      it('keeps the single ref shape when all STI children resolve to the same serializer', () => {
+        const results = subject({
+          type: 'object',
+          properties: {
+            result: {
+              $serializable: Balloon,
+              $serializableSerializerKey: 'sameForAllSti',
+            },
+          },
+        } as OpenapiBodySegment)
+
+        expect(results.openapi).toEqual({
+          type: 'object',
+          properties: {
+            result: {
+              $ref: '#/components/schemas/BalloonSummary',
+            },
+          },
+        })
+        expect(results.referencedSerializers).toEqual([BalloonSummarySerializer])
       })
     })
   })

--- a/src/openapi-renderer/body-segment.ts
+++ b/src/openapi-renderer/body-segment.ts
@@ -33,6 +33,7 @@ import isBlankDescription from './helpers/isBlankDescription.js'
 import maybeNullOpenapiShorthandToOpenapiShorthand from './helpers/maybeNullOpenapiShorthandToOpenapiShorthand.js'
 import primitiveOpenapiStatementToOpenapi from './helpers/primitiveOpenapiStatementToOpenapi.js'
 import schemaToRef from './helpers/schemaToRef.js'
+import serializersAndRefsFromSerializableRef from './helpers/serializersAndRefsFromSerializableRef.js'
 import SerializerOpenapiRenderer from './SerializerOpenapiRenderer.js'
 
 export interface OpenapiBodySegmentRendererOpts {
@@ -653,20 +654,43 @@ The following values will be allowed:
   private serializableStatement(bodySegment: OpenapiBodySegment): ReferencedSerializersAndOpenapiSchemaBody {
     const serializableRef = bodySegment as OpenapiSchemaShorthandExpressionSerializableRef
     const key = serializableRef.$serializableSerializerKey || serializableRef.key || 'default'
-    const serializer = DreamApp.system.inferSerializerFromDreamOrViewModel(
-      serializableRef.$serializable.prototype as Dream,
-      key,
-    )
+    const { serializers, refs } = serializersAndRefsFromSerializableRef(serializableRef, {
+      casing: this.casing,
+      suppressResponseEnums: this.suppressResponseEnums,
+    })
 
-    if (!serializer)
+    if (serializers.length === 0)
       throw new Error(
         `Failed to locate serializers getter from: ${serializableRef.$serializable.name} using key: ${key}`,
       )
 
-    return this.serializerStatement({
-      $serializer: serializer,
-      ...serializableRef,
-    })
+    if (serializers.length === 1) {
+      return this.serializerStatement({
+        $serializer: serializers[0],
+        ...serializableRef,
+      })
+    }
+
+    const serializerAnyOf = { anyOf: refs }
+
+    if (serializableRef.many) {
+      return {
+        referencedSerializers: serializers,
+        openapi: {
+          type: serializableRef.maybeNull ? ['array', 'null'] : 'array',
+          items: serializerAnyOf,
+        },
+      }
+    }
+
+    if (serializableRef.maybeNull) {
+      return {
+        referencedSerializers: serializers,
+        openapi: { anyOf: [...refs, { type: 'null' }] },
+      }
+    }
+
+    return { referencedSerializers: serializers, openapi: serializerAnyOf }
   }
 
   /**

--- a/src/openapi-renderer/helpers/allSerializersFromHandWrittenOpenapi.ts
+++ b/src/openapi-renderer/helpers/allSerializersFromHandWrittenOpenapi.ts
@@ -3,8 +3,8 @@
 import { OpenapiSchemaBodyShorthand, OpenapiShorthandPrimitiveTypes } from '@rvoh/dream/openapi'
 import { DreamModelSerializerType, SimpleObjectSerializerType } from '@rvoh/dream/types'
 
-import { DreamApp } from '@rvoh/dream'
 import isObject from '../../helpers/isObject.js'
+import serializersAndRefsFromSerializableRef from './serializersAndRefsFromSerializableRef.js'
 
 /**
  * @internal
@@ -66,12 +66,9 @@ function extractSerializers(
     serializers.add(value.$serializer)
     //
   } else if (value.$serializable) {
-    const foundSerializers = DreamApp.system.inferSerializersFromDreamClassOrViewModelClass(
-      value.$serializable,
-      value.$serializableSerializerKey,
+    serializersAndRefsFromSerializableRef(value).serializers.forEach(serializer =>
+      serializers.add(serializer),
     )
-
-    foundSerializers.forEach(serializer => serializers.add(serializer))
 
     //
   } else if (isObject(value)) {

--- a/src/openapi-renderer/helpers/allSerializersToRefsInOpenapi.ts
+++ b/src/openapi-renderer/helpers/allSerializersToRefsInOpenapi.ts
@@ -2,10 +2,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { DreamApp } from '@rvoh/dream'
 import { OpenapiSchemaBodyShorthand, OpenapiShorthandPrimitiveTypes } from '@rvoh/dream/openapi'
 import isObject from '../../helpers/isObject.js'
 import SerializerOpenapiRenderer from '../SerializerOpenapiRenderer.js'
+import serializersAndRefsFromSerializableRef from './serializersAndRefsFromSerializableRef.js'
 
 /**
  * @internal
@@ -73,14 +73,8 @@ function transformValue(value: any): any {
     }
     //
   } else if (value.$serializable) {
-    const { $serializable, $serializableSerializerKey, ...rest } = value
-
-    const foundSerializers = DreamApp.system.inferSerializersFromDreamClassOrViewModelClass(
-      $serializable,
-      $serializableSerializerKey,
-    )
-
-    const refs = foundSerializers.map(serializer => new SerializerOpenapiRenderer(serializer).serializerRef)
+    const { $serializable, $serializableSerializerKey, key, ...rest } = value
+    const { refs } = serializersAndRefsFromSerializableRef({ $serializable, $serializableSerializerKey, key })
 
     if (refs.length === 0) return rest
     if (refs.length === 1) {

--- a/src/openapi-renderer/helpers/serializersAndRefsFromSerializableRef.ts
+++ b/src/openapi-renderer/helpers/serializersAndRefsFromSerializableRef.ts
@@ -1,0 +1,41 @@
+import { DreamApp } from '@rvoh/dream'
+import {
+  OpenapiSchemaExpressionRef,
+  OpenapiSchemaShorthandExpressionSerializableRef,
+} from '@rvoh/dream/openapi'
+import { DreamModelSerializerType, SerializerCasing, SimpleObjectSerializerType } from '@rvoh/dream/types'
+import { sortBy, uniq } from '@rvoh/dream/utils'
+import SerializerOpenapiRenderer from '../SerializerOpenapiRenderer.js'
+
+export default function serializersAndRefsFromSerializableRef(
+  serializableRef: OpenapiSchemaShorthandExpressionSerializableRef,
+  {
+    casing = 'camel',
+    suppressResponseEnums = false,
+  }: {
+    casing?: SerializerCasing
+    suppressResponseEnums?: boolean
+  } = {},
+): {
+  serializers: (DreamModelSerializerType | SimpleObjectSerializerType)[]
+  refs: OpenapiSchemaExpressionRef[]
+} {
+  const key = serializableRef.$serializableSerializerKey || serializableRef.key || 'default'
+  const serializerRefs = sortBy(
+    uniq(
+      DreamApp.system.inferSerializersFromDreamClassOrViewModelClass(serializableRef.$serializable, key),
+    ).map(serializer => ({
+      serializer,
+      ref: new SerializerOpenapiRenderer(serializer, {
+        casing,
+        suppressResponseEnums,
+      }).serializerRef,
+    })),
+    ({ ref }) => ref.$ref,
+  )
+
+  return {
+    serializers: serializerRefs.map(({ serializer }) => serializer),
+    refs: serializerRefs.map(({ ref }) => ref),
+  }
+}

--- a/test-app/src/types/openapi/openapi.d.ts
+++ b/test-app/src/types/openapi/openapi.d.ts
@@ -3544,15 +3544,6 @@ export interface components {
             };
             content?: never;
         };
-        /** @description The request failed to process due to validation errors with the provided values */
-        ValidationErrors: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": components["schemas"]["ValidationErrors"];
-            };
-        };
         /** @description the server encountered an unexpected condition that prevented it from fulfilling the request */
         InternalServerError: {
             headers: {


### PR DESCRIPTION
## Summary
- route `` response shorthand through plural Dream serializer inference so STI base models expand to child serializers
- emit `anyOf` for multi-serializer STI refs while preserving single `` output for non-STI and shared serializer keys
- add body-segment regression coverage for STI, many, nullable, and shared-key cases
- bump package version to 3.8.6 and update CHANGELOG

## Verification
- `pnpm uspec spec/unit/openapi-renderer/body-segment/parse.spec.ts spec/unit/openapi-renderer/helpers/allSerializersToRefsInOpenapi.spec.ts spec/unit/openapi-renderer/helpers/allSerializersFromHandWrittenOpenapi.spec.ts spec/unit/openapi-renderer/serializer/DreamSerializer/rendersMany.spec.ts`
- `pnpm build:test-app`
- `pnpm prettier src/openapi-renderer/body-segment.ts spec/unit/openapi-renderer/body-segment/parse.spec.ts package.json CHANGELOG.md --check`