### PR TITLE
Exclude undefined from paramsFor/extractParams return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.10.1
+
+- Tightened the inferred return type for `Params.for`, `Params.extract`, `PsychicController#paramsFor`, and `PsychicController#extractParams` so optional extracted keys no longer also include `undefined` in their value unions. This matches runtime behavior, where missing or explicitly `undefined` request values are omitted from the returned object. Nullable columns still infer `T | null`, and `{ array: true }` returns the same tightened element type for nested model-array request bodies.
+
 ## 3.10.0
 
 - Security hardening (audit 2026-07-01):

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "author": "RVOHealth",
   "publishConfig": {
     "access": "public"

--- a/spec/unit/openapi-renderer/serializer/DreamSerializer/delegatedAttribute.spec.ts
+++ b/spec/unit/openapi-renderer/serializer/DreamSerializer/delegatedAttribute.spec.ts
@@ -106,6 +106,46 @@ describe('DreamSerializer delegated attributes', () => {
     })
   })
 
+  context('when repeating the same key using required: false to shadow a default', () => {
+    it('keeps the key required because the fallback declaration still writes it', () => {
+      const MySerializer = (data: Pet) =>
+        DreamSerializer(Pet, data)
+          .delegatedAttribute('user', 'name', { openapi: 'string' })
+          .delegatedAttribute('user', 'name', { openapi: 'string', required: false })
+
+      const serializerOpenapiRenderer = new SerializerOpenapiRenderer(MySerializer)
+      expect(serializerOpenapiRenderer.renderedOpenapi().openapi).toMatchObject({
+        required: ['name'],
+        properties: {
+          name: {
+            type: 'string',
+          },
+        },
+      })
+    })
+
+    it('uses the renamed output key in properties and required when shadowing with as', () => {
+      const MySerializer = (data: Pet) =>
+        DreamSerializer(Pet, data)
+          .delegatedAttribute('user', 'name', { as: 'displayName', openapi: 'string' })
+          .delegatedAttribute('user', 'name', {
+            as: 'displayName',
+            openapi: 'string',
+            required: false,
+          })
+
+      const serializerOpenapiRenderer = new SerializerOpenapiRenderer(MySerializer)
+      expect(serializerOpenapiRenderer.renderedOpenapi().openapi).toMatchObject({
+        required: ['displayName'],
+        properties: {
+          displayName: {
+            type: 'string',
+          },
+        },
+      })
+    })
+  })
+
   context('optional inferred from the association', () => {
     context('when the column is already nullable', () => {
       it('does not redundantly wrap with null', () => {

--- a/spec/unit/openapi-renderer/serializer/ObjectSerializer/delegatedAttribute.spec.ts
+++ b/spec/unit/openapi-renderer/serializer/ObjectSerializer/delegatedAttribute.spec.ts
@@ -9,6 +9,7 @@ interface User {
 interface Pet {
   name?: string
   user?: User
+  defaultUser?: User
 }
 
 describe('ObjectSerializer delegated attributes', () => {
@@ -38,6 +39,46 @@ describe('ObjectSerializer delegated attributes', () => {
       const serializerOpenapiRenderer = new SerializerOpenapiRenderer(MySerializer)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
       expect((serializerOpenapiRenderer.renderedOpenapi().openapi as any).required).toEqual([])
+    })
+  })
+
+  context('when repeating the same key using required: false to shadow a default', () => {
+    it('keeps the key required because the fallback declaration still writes it', () => {
+      const MySerializer = (data: Pet) =>
+        ObjectSerializer(data)
+          .delegatedAttribute('defaultUser', 'name', { openapi: 'string' })
+          .delegatedAttribute('user', 'name', { openapi: 'string', required: false })
+
+      const serializerOpenapiRenderer = new SerializerOpenapiRenderer(MySerializer)
+      expect(serializerOpenapiRenderer.renderedOpenapi().openapi).toMatchObject({
+        required: ['name'],
+        properties: {
+          name: {
+            type: 'string',
+          },
+        },
+      })
+    })
+
+    it('uses the renamed output key in properties and required when shadowing with as', () => {
+      const MySerializer = (data: Pet) =>
+        ObjectSerializer(data)
+          .delegatedAttribute('defaultUser', 'name', { as: 'displayName', openapi: 'string' })
+          .delegatedAttribute('user', 'name', {
+            as: 'displayName',
+            openapi: 'string',
+            required: false,
+          })
+
+      const serializerOpenapiRenderer = new SerializerOpenapiRenderer(MySerializer)
+      expect(serializerOpenapiRenderer.renderedOpenapi().openapi).toMatchObject({
+        required: ['displayName'],
+        properties: {
+          displayName: {
+            type: 'string',
+          },
+        },
+      })
     })
   })
 

--- a/spec/unit/security/extract-params.security.spec.ts
+++ b/spec/unit/security/extract-params.security.spec.ts
@@ -79,6 +79,9 @@ describe('PsychicController extract-params primitives (R-011)', () => {
         }
 
         const result = controller.extractParams(User, ['name'], { key: 'users', array: true })
+        const typedResult: Partial<{ name: string | null }>[] = result
+
+        expect(typedResult).toEqual(result)
         expect(result).toEqual([{ name: 'a' }, { name: 'b' }])
       })
     })

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -54,6 +54,7 @@ import OpenapiPayloadValidator from '../openapi-renderer/helpers/OpenapiPayloadV
 import { cacheStringify, getCachedStringify } from '../openapi-renderer/helpers/stringify-cache.js'
 import PsychicApp from '../psychic-app/index.js'
 import Params, {
+  type ExtractedDreamParamSafeAttributes,
   ExtractParamsOpts,
   ParamsCastOptions,
   ParamsForOpts,
@@ -548,14 +549,11 @@ export default class PsychicController {
     ReturnPartialType extends ForOpts['only'] extends readonly (keyof DreamParamSafeAttributes<
       InstanceType<T>
     >)[]
-      ? Partial<{
-          [K in ForOpts['only'][number] & keyof ParamSafeAttrs]: ParamSafeAttrs[K & keyof ParamSafeAttrs]
-        }>
-      : Partial<{
-          [K in ParamSafeColumns[number & keyof ParamSafeColumns] & string]: DreamParamSafeAttributes<
-            InstanceType<T>
-          >[K & keyof DreamParamSafeAttributes<InstanceType<T>>]
-        }>,
+      ? ExtractedDreamParamSafeAttributes<ParamSafeAttrs, ForOpts['only'][number] & keyof ParamSafeAttrs>
+      : ExtractedDreamParamSafeAttributes<
+          ParamSafeAttrs,
+          ParamSafeColumns[number & keyof ParamSafeColumns] & string & keyof ParamSafeAttrs
+        >,
     ReturnPayload extends ForOpts['array'] extends true ? ReturnPartialType[] : ReturnPartialType,
   >(this: PsychicController, dreamClass: T, opts?: ForOpts): ReturnPayload {
     return Params.for(
@@ -605,9 +603,10 @@ export default class PsychicController {
     const AllowedArray extends readonly (keyof DreamParamSafeAttributes<I>)[],
     OptsType extends StrictInterface<OptsType, ExtractParamsOpts>,
     ParamSafeAttrs extends DreamParamSafeAttributes<I>,
-    ReturnPartial extends Partial<{
-      [K in AllowedArray[number] & keyof ParamSafeAttrs]: ParamSafeAttrs[K & keyof ParamSafeAttrs]
-    }>,
+    ReturnPartial extends ExtractedDreamParamSafeAttributes<
+      ParamSafeAttrs,
+      AllowedArray[number] & keyof ParamSafeAttrs
+    >,
     ReturnPayload extends OptsType['array'] extends true ? ReturnPartial[] : ReturnPartial,
   >(this: PsychicController, dreamClass: T, allowed: AllowedArray, opts?: OptsType): ReturnPayload {
     const source = opts?.key ? (this.params[opts.key] as typeof this.params) || {} : this.params

--- a/src/server/helpers/openapiParamNamesForDreamClass.ts
+++ b/src/server/helpers/openapiParamNamesForDreamClass.ts
@@ -6,7 +6,10 @@ import {
   UpdateableProperties,
 } from '@rvoh/dream/types'
 import type { VirtualAttributeStatement } from '../../openapi-renderer/helpers/dreamColumnOpenapiShape.js'
-import type { OpenAPIDreamModelRequestBodyModifications } from '../params.js'
+import type {
+  ExtractedDreamParamSafeAttributes,
+  OpenAPIDreamModelRequestBodyModifications,
+} from '../params.js'
 import paramNamesForDreamClass from './paramNamesForDreamClass.js'
 
 export default function openapiParamNamesForDreamClass<
@@ -28,14 +31,11 @@ export default function openapiParamNamesForDreamClass<
   ReturnPartialType extends ForOpts['only'] extends readonly (keyof DreamParamSafeAttributes<
     InstanceType<T>
   >)[]
-    ? Partial<{
-        [K in ForOpts['only'][number] & keyof ParamSafeAttrs]: ParamSafeAttrs[K & keyof ParamSafeAttrs]
-      }>
-    : Partial<{
-        [K in ParamSafeColumns[number & keyof ParamSafeColumns] & string]: DreamParamSafeAttributes<
-          InstanceType<T>
-        >[K & keyof DreamParamSafeAttributes<InstanceType<T>>]
-      }>,
+    ? ExtractedDreamParamSafeAttributes<ParamSafeAttrs, ForOpts['only'][number] & keyof ParamSafeAttrs>
+    : ExtractedDreamParamSafeAttributes<
+        ParamSafeAttrs,
+        ParamSafeColumns[number & keyof ParamSafeColumns] & string & keyof ParamSafeAttrs
+      >,
   ReturnPartialTypeWithIncluding extends ForOpts['including'] extends readonly (keyof UpdateableProperties<
     InstanceType<T>
   >)[]

--- a/src/server/helpers/paramNamesForDreamClass.ts
+++ b/src/server/helpers/paramNamesForDreamClass.ts
@@ -1,6 +1,6 @@
 import { Dream } from '@rvoh/dream'
 import { DreamParamSafeAttributes, DreamParamSafeColumnNames, StrictInterface } from '@rvoh/dream/types'
-import type { ParamsForOpts } from '../params.js'
+import type { ExtractedDreamParamSafeAttributes, ParamsForOpts } from '../params.js'
 
 export default function paramNamesForDreamClass<
   T extends typeof Dream,
@@ -17,14 +17,11 @@ export default function paramNamesForDreamClass<
   ReturnPartialType extends ForOpts['only'] extends readonly (keyof DreamParamSafeAttributes<
     InstanceType<T>
   >)[]
-    ? Partial<{
-        [K in ForOpts['only'][number] & keyof ParamSafeAttrs]: ParamSafeAttrs[K & keyof ParamSafeAttrs]
-      }>
-    : Partial<{
-        [K in ParamSafeColumns[number & keyof ParamSafeColumns] & string]: DreamParamSafeAttributes<
-          InstanceType<T>
-        >[K & keyof DreamParamSafeAttributes<InstanceType<T>>]
-      }>,
+    ? ExtractedDreamParamSafeAttributes<ParamSafeAttrs, ForOpts['only'][number] & keyof ParamSafeAttrs>
+    : ExtractedDreamParamSafeAttributes<
+        ParamSafeAttrs,
+        ParamSafeColumns[number & keyof ParamSafeColumns] & string & keyof ParamSafeAttrs
+      >,
   RetArray = (keyof ReturnPartialType)[],
 >(dreamClass: T, { only }: ForOpts = {} as ForOpts): RetArray {
   return Array.isArray(only)

--- a/src/server/params.ts
+++ b/src/server/params.ts
@@ -34,6 +34,13 @@ import { Inc } from '../i18n/conf/types.js'
 import type { VirtualAttributeStatement } from '../openapi-renderer/helpers/dreamColumnOpenapiShape.js'
 import paramNamesForDreamClass from './helpers/paramNamesForDreamClass.js'
 
+export type ExtractedDreamParamSafeAttributes<
+  ParamSafeAttrs,
+  ParamNames extends keyof ParamSafeAttrs,
+> = Partial<{
+  [K in ParamNames]: Exclude<ParamSafeAttrs[K], undefined>
+}>
+
 export default class Params {
   /**
    * ### .for
@@ -67,14 +74,11 @@ export default class Params {
     ReturnPartialType extends ForOpts['only'] extends readonly (keyof DreamParamSafeAttributes<
       InstanceType<T>
     >)[]
-      ? Partial<{
-          [K in ForOpts['only'][number] & keyof ParamSafeAttrs]: ParamSafeAttrs[K & keyof ParamSafeAttrs]
-        }>
-      : Partial<{
-          [K in ParamSafeColumns[number & keyof ParamSafeColumns] &
-            string &
-            keyof ParamSafeAttrs]: ParamSafeAttrs[K & keyof ParamSafeAttrs]
-        }>,
+      ? ExtractedDreamParamSafeAttributes<ParamSafeAttrs, ForOpts['only'][number] & keyof ParamSafeAttrs>
+      : ExtractedDreamParamSafeAttributes<
+          ParamSafeAttrs,
+          ParamSafeColumns[number & keyof ParamSafeColumns] & string & keyof ParamSafeAttrs
+        >,
     ReturnPayload extends ForOpts['array'] extends true ? ReturnPartialType[] : ReturnPartialType,
   >(params: object, dreamClass: T, forOpts: ForOpts = {} as ForOpts): ReturnPayload {
     const { array = false } = forOpts
@@ -195,9 +199,10 @@ export default class Params {
     const AllowedArray extends readonly (keyof DreamParamSafeAttributes<I>)[],
     OptsType extends StrictInterface<OptsType, ExtractParamsOpts>,
     ParamSafeAttrs extends DreamParamSafeAttributes<I>,
-    ReturnPartial extends Partial<{
-      [K in AllowedArray[number] & keyof ParamSafeAttrs]: ParamSafeAttrs[K & keyof ParamSafeAttrs]
-    }>,
+    ReturnPartial extends ExtractedDreamParamSafeAttributes<
+      ParamSafeAttrs,
+      AllowedArray[number] & keyof ParamSafeAttrs
+    >,
     ReturnPayload extends OptsType['array'] extends true ? ReturnPartial[] : ReturnPartial,
   >(params: object, dreamClass: T, allowed: AllowedArray, opts?: OptsType): ReturnPayload {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

Tightens the inferred return type for `Params.for`, `Params.extract`, `PsychicController#paramsFor`, and `PsychicController#extractParams` so optional extracted keys no longer also include `undefined` in their value unions.

This matches runtime behavior: `Params.for` skips any param whose value is `undefined` (`if (params[columnName] === undefined) continue`), so the returned object never carries an `undefined` value. Nullable columns still cast to `null` and continue to infer `T | null`. `{ array: true }` returns the same tightened element type for nested model-array request bodies.

## Implementation

Introduces one shared type in `src/server/params.ts`:

```ts
ExtractedDreamParamSafeAttributes<ParamSafeAttrs, ParamNames> =
  Partial<{ [K in ParamNames]: Exclude<ParamSafeAttrs[K], undefined> }>
```

and swaps it into the four structurally-identical return-type computations plus the two `*ParamNamesForDreamClass` helpers, unifying the previously divergent `else`-branch key/value computations.

This is meaningful under the repo's `exactOptionalPropertyTypes: true` setting, where an optional key no longer implies `undefined` in its value union.

## Testing

- `pnpm build:test-app` compiles clean (ESM + CJS)
- Params/extract/paramsFor specs pass (272/272)
- Added a type-level assertion in the extract-params security spec that fails before this change and passes after (`Partial<{ name: string | null }>[]` accepts the result for a nullable column)

🤖 Generated with [Claude Code](https://claude.com/claude-code)