### PR TITLE
Document boolean/boolean[] in g:resource --help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.11.1
+
+- Added `boolean` / `boolean[]` to the "supported types" list in `baseColumnsWithTypesDescription` (`g:resource --help` and other generators sharing this help text), which previously documented every other column shorthand type except `boolean` even though it is a fully-supported column type.
+
 ## 3.11.0
 
 - `psy diff:openapi --fail-on-breaking` now exits nonzero when the diff tooling itself fails (oasdiff invocation error, spec file missing on the current branch, head-branch spec unreadable), instead of reporting "no breaking changes" and passing the CI gate. Tool failures throw a new `OpenApiSpecDiffToolFailureError` whose message explicitly distinguishes "the diff tool failed (inconclusive)" from "breaking changes found". Failed oasdiff invocations are now propagated as structured errors rather than string-matched on `'Command failed'`, and a failed head-branch retrieval for one file is recorded as that file's error (other files are still compared) instead of aborting the whole run with a raw error. Without `--fail-on-breaking` (informational mode), tool failures are printed loudly but the exit code is unchanged. A genuine no-changes run still exits 0, and the breaking-changes path is unchanged.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "author": "RVOHealth",
   "publishConfig": {
     "access": "public"

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -50,6 +50,9 @@ ${INDENT}    - timetz[]
 ${INDENT}    - integer
 ${INDENT}    - integer[]
 ${INDENT}
+${INDENT}    - boolean
+${INDENT}    - boolean[]
+${INDENT}
 ${INDENT}    - decimal:
 ${INDENT}    - decimal[]:
 ${INDENT}        precision,scale is required, e.g.: volume:decimal:3,2 or volume:decimal:3,2:optional


### PR DESCRIPTION
## Summary

`boolean` is a fully-supported column shorthand type but was missing from the "supported types" help text (`baseColumnsWithTypesDescription` in `src/cli/index.ts`), which documents `g:resource` and other generators. This is the `psychic` counterpart to the same fix in `dream`'s `g:migration --help` (`dream` PR #737) — same omission, same fix, duplicated help text between the two repos.

Added `boolean` / `boolean[]` entries next to the existing `integer`/`integer[]` entry.

## Review

Small diff (9 lines) — reviewed with a correctness/security/adversarial pass plus a cross-model pass (`codex`). Both reviewers found nothing.

## Verification

- `pnpm lint`: pass
- `pnpm build:test-app`: pass
- `pnpm uspec`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
