### PR TITLE
Wrap boot-time OpenAPI generation failures with context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.11.2
+
+- Errors thrown while generating the per-`openapiName` OpenAPI cache during `PsychicApp.init` (e.g. a serializer misconfiguration) are now wrapped with context naming the step and the failing document — "Failed to generate the OpenAPI document 'default' during PsychicApp.init." — with the original error preserved via `{ cause }` (and its message embedded). Previously the underlying error propagated raw, with nothing tying it to OpenAPI generation or identifying which document failed. Other documents and the success path are unchanged.
+
 ## 3.11.1
 
 - Added `boolean` / `boolean[]` to the "supported types" list in `baseColumnsWithTypesDescription` (`g:resource --help` and other generators sharing this help text), which previously documented every other column shorthand type except `boolean` even though it is a fully-supported column type.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "author": "RVOHealth",
   "publishConfig": {
     "access": "public"

--- a/spec/unit/psychic-application/init.spec.ts
+++ b/spec/unit/psychic-application/init.spec.ts
@@ -1,6 +1,7 @@
 import PsychicAppInitMissingApiRoot from '../../../src/error/psychic-app/init-missing-api-root.js'
 import PsychicAppInitMissingCallToLoadControllers from '../../../src/error/psychic-app/init-missing-call-to-load-controllers.js'
 import PsychicAppInitMissingRoutesCallback from '../../../src/error/psychic-app/init-missing-routes-callback.js'
+import OpenapiAppRenderer from '../../../src/openapi-renderer/app.js'
 import * as LoadControllersModule from '../../../src/psychic-app/helpers/import/importControllers.js'
 import PsychicApp from '../../../src/psychic-app/index.js'
 import { _testOnlyClearOpenapiCache } from '../../../src/psychic-app/openapi-cache.js'
@@ -40,6 +41,95 @@ describe('PsychicApp#init', () => {
 
         await initializePsychicApp()
         process.env.SKIP_TEST_ROUTE = undefined
+      })
+    })
+  })
+
+  context('when generating an openapi document throws', () => {
+    async function initAndCatch(): Promise<Error> {
+      let thrownError: Error | undefined
+      try {
+        await initializePsychicApp()
+      } catch (err) {
+        thrownError = err as Error
+      }
+
+      expect(thrownError).toBeInstanceOf(Error)
+      return thrownError!
+    }
+
+    it('wraps the error with the failing openapiName and the PsychicApp.init step, embedding the original message and preserving the original error as cause', async () => {
+      const originalError = new Error('serializer misconfiguration')
+      vi.spyOn(OpenapiAppRenderer, '_toObject').mockImplementation(() => {
+        throw originalError
+      })
+
+      // blow away the openapi cache, so that re-running
+      // initializePsychicApp reaches the generation path
+      // (cacheOpenapiDoc early-returns for already-cached names)
+      _testOnlyClearOpenapiCache('default')
+
+      const thrownError = await initAndCatch()
+
+      expect(thrownError.message).toContain(
+        "Failed to generate the OpenAPI document 'default' during PsychicApp.init.",
+      )
+      expect(thrownError.message).toContain('serializer misconfiguration')
+      expect(thrownError.cause).toBe(originalError)
+    })
+
+    it('names the specific failing document, not just the first registered one', async () => {
+      // populate the openapi cache for every registered openapiName,
+      // then clear only 'admin', so it is the only document regenerated
+      // (cacheOpenapiDoc early-returns for already-cached names)
+      await initializePsychicApp()
+
+      vi.spyOn(OpenapiAppRenderer, '_toObject').mockImplementation(() => {
+        throw new Error('boom')
+      })
+      _testOnlyClearOpenapiCache('admin')
+
+      const thrownError = await initAndCatch()
+
+      expect(thrownError.message).toContain(
+        "Failed to generate the OpenAPI document 'admin' during PsychicApp.init.",
+      )
+    })
+
+    context('when the thrown value is not an Error instance', () => {
+      it('embeds a stringified representation of a thrown string, preserving it as cause', async () => {
+        await initializePsychicApp()
+
+        vi.spyOn(OpenapiAppRenderer, '_toObject').mockImplementation(() => {
+          // eslint-disable-next-line @typescript-eslint/only-throw-error
+          throw 'string boom'
+        })
+        _testOnlyClearOpenapiCache('default')
+
+        const thrownError = await initAndCatch()
+
+        expect(thrownError.message).toContain(
+          "Failed to generate the OpenAPI document 'default' during PsychicApp.init.",
+        )
+        expect(thrownError.message).toContain('string boom')
+        expect(thrownError.cause).toBe('string boom')
+      })
+
+      it('wraps a thrown null without crashing the catch block, preserving it as cause', async () => {
+        await initializePsychicApp()
+
+        vi.spyOn(OpenapiAppRenderer, '_toObject').mockImplementation(() => {
+          // eslint-disable-next-line @typescript-eslint/only-throw-error
+          throw null
+        })
+        _testOnlyClearOpenapiCache('default')
+
+        const thrownError = await initAndCatch()
+
+        expect(thrownError.message).toContain(
+          "Failed to generate the OpenAPI document 'default' during PsychicApp.init.",
+        )
+        expect(thrownError.cause).toBeNull()
       })
     })
   })

--- a/src/psychic-app/index.ts
+++ b/src/psychic-app/index.ts
@@ -176,7 +176,16 @@ export default class PsychicApp {
    */
   private buildOpenapiCache(): void {
     Object.keys(this.openapi).forEach(openapiName => {
-      this.cacheOpenapiDoc(openapiName)
+      try {
+        this.cacheOpenapiDoc(openapiName)
+      } catch (cause) {
+        const message = cause instanceof Error ? cause.message : String(cause)
+        throw new Error(
+          `Failed to generate the OpenAPI document '${openapiName}' during PsychicApp.init. The error thrown was:
+  ${message}`,
+          { cause },
+        )
+      }
     })
   }
 


### PR DESCRIPTION
Errors thrown while `PsychicApp.init` generates the per-`openapiName` OpenAPI cache (e.g. a serializer misconfiguration) previously propagated raw, naming neither the step nor the failing document. They are now wrapped in an `Error` whose message names both — `Failed to generate the OpenAPI document '<openapiName>' during PsychicApp.init.` — embedding the original message and preserving the original thrown value via `{ cause }`, matching the `PsychicServer#boot` rethrow precedent. Non-`Error` throws (a bare string, `null`) are formatted safely rather than crashing the wrapper. Other documents and the success path are unchanged.

Includes unit specs for the wrapped failure (embedded original message, `cause` identity, non-`Error` throws, and per-document naming via a non-default `openapiName`), a CHANGELOG entry, and the version bump to 3.11.2.

Verification: `pnpm build:test-app`, `pnpm lint`, `pnpm uspec` (168 files, 1307 tests), `pnpm fspec` (2 files, 3 tests) — all passing on the final tree.

Follow-up (not this PR): `PsychicApp.init` caches the app globally (`cachePsychicApp`) before the OpenAPI cache builds, so a failed init leaves a globally retrievable half-initialized app; pre-existing behavior, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wykh7CCKwEL5VRx1uD8VEY
