### PR TITLE
Reach paramSafeColumnsOrFallback through a typed back-door

### DIFF
--- a/src/generate/helpers/paramSafeColumnNamesFromCliTokens.ts
+++ b/src/generate/helpers/paramSafeColumnNamesFromCliTokens.ts
@@ -3,10 +3,9 @@ import parseAttribute from './parseAttribute.js'
 /**
  * Derive the param-safe column names from the `columnsWithTypes` CLI tokens
  * supplied to `psy g:resource`. Filters the same set Dream's
- * `defaultParamSafeColumns()` filters at runtime
- * (`dream/src/Dream.ts:826-844`) — accepted deliberate duplication, since
- * the generator runs before a live model class exists (greenfield) and
- * therefore cannot introspect via `ModelClass.paramSafeColumnsOrFallback()`.
+ * `defaultParamSafeColumns()` filters at runtime — accepted deliberate
+ * duplication, since the generator runs before a live model class exists
+ * (greenfield) and therefore cannot introspect one.
  *
  * Delegates token parsing + camelCase normalization to the shared
  * `parseAttribute` helper so the casing emitted into generated controllers

--- a/src/server/helpers/paramNamesForDreamClass.ts
+++ b/src/server/helpers/paramNamesForDreamClass.ts
@@ -25,8 +25,8 @@ export default function paramNamesForDreamClass<
   RetArray = (keyof ReturnPartialType)[],
 >(dreamClass: T, { only }: ForOpts = {} as ForOpts): RetArray {
   return Array.isArray(only)
-    ? ((dreamClass.paramSafeColumnsOrFallback() as string[]).filter(column =>
+    ? ((dreamClass['paramSafeColumnsOrFallback']() as string[]).filter(column =>
         only.includes(column as (typeof only)[number]),
       ) as unknown as RetArray)
-    : (dreamClass.paramSafeColumnsOrFallback() as string[] as RetArray)
+    : (dreamClass['paramSafeColumnsOrFallback']() as string[] as RetArray)
 }

--- a/src/server/helpers/paramNamesForDreamClass.ts
+++ b/src/server/helpers/paramNamesForDreamClass.ts
@@ -24,9 +24,19 @@ export default function paramNamesForDreamClass<
       >,
   RetArray = (keyof ReturnPartialType)[],
 >(dreamClass: T, { only }: ForOpts = {} as ForOpts): RetArray {
+  // `paramSafeColumnsOrFallback` is a Dream internal, reached through the bracketed
+  // back-door (the same escape hatch psychic uses for `virtualAttributes`). Dream
+  // declares it `private static`, which TypeScript erases to an untyped member in
+  // `Dream.d.ts`, so the member is cast to a concrete signature here to keep the
+  // return shape checked instead of degrading to `any`. `.call` preserves `this`,
+  // which the Dream implementation relies on.
+  const paramSafeColumns = (
+    dreamClass['paramSafeColumnsOrFallback'] as unknown as (this: T) => string[]
+  ).call(dreamClass)
+
   return Array.isArray(only)
-    ? ((dreamClass['paramSafeColumnsOrFallback']() as string[]).filter(column =>
+    ? (paramSafeColumns.filter(column =>
         only.includes(column as (typeof only)[number]),
       ) as unknown as RetArray)
-    : (dreamClass['paramSafeColumnsOrFallback']() as string[] as RetArray)
+    : (paramSafeColumns as unknown as RetArray)
 }


### PR DESCRIPTION
Moves psychic's two `paramSafeColumnsOrFallback` call sites onto the bracketed back-door, so they keep working when dream makes that member non-public.

**Stacked on #531** (`fix/openapi-init-error-context`) — merge that first. No version bump and no changelog entry: this is an internal call-site rewrite with no consumer-observable behavior change, which is what `AGENTS.md` scopes bumps to.

## Why

dream's companion PR ([rvohealth/dream#745](https://github.com/rvohealth/dream/pull/745), shipping as dream 2.26.0) makes `Dream.paramSafeColumnsOrFallback` `private static`, so `SomeModel.paramSafeColumnsOrFallback()` becomes a compile error for application code. Pasted into `requestBody: { params: [...] }` it silently advertised a model's whole writable surface — column names and types — in the public OpenAPI document, and re-widened every time the model gained a column. Psychic 3.9.0 removed the implicit include-all default; that change closes the explicit way back to it.

Bracket access is the deliberate escape hatch, and the same one psychic already uses to reach `dreamClass['virtualAttributes']`.

## The typed cast is the point, not incidental

Bracket access alone is not enough, and review caught this before it shipped. TypeScript emits a `private static` member into the `.d.ts` without its signature (`private static paramSafeColumnsOrFallback;`), so once psychic bumps to dream 2.26.0 a bare `dreamClass['paramSafeColumnsOrFallback']()` resolves to `any` — and psychic's own `pnpm lint` then fails with two `@typescript-eslint/no-unsafe-call` errors, on the very upgrade this change exists to enable. It would not have failed today, because CI resolves a published dream where the member is still public, so this would have landed silently and broken the dependency bump later.

The call is therefore cast to `(this: T) => string[]` and invoked with an explicit receiver, since dream's implementation reads `this.defaultParamSafeColumns()` and `this.prototype`. Verified by patching the installed dream's `.d.ts` to the private-erased form: pre-fix reproduces both `no-unsafe-call` errors, post-fix lints clean, and a type probe confirms the result is `string[]` rather than laundered `any`. Lints clean against the currently-locked dream 2.14.0 too.

Also folds in a one-line doc fix: a comment in `paramSafeColumnNamesFromCliTokens.ts` cited a dream line range that had already gone stale, now citing the symbol instead.

## Verification

`pnpm build:test-app` and `pnpm lint` both clean. Unit specs pass apart from four pre-existing failures in `spec/unit/bin/helpers/OpenapiSpecDiff.spec.ts`, which shell out to git over SSH and fail in this environment with `Permission denied (publickey)` — confirmed identical with the changes stashed. Feature specs not run, per `AGENTS.md`.

## Known follow-up, not in this PR

Public TSDoc in `src/controller/index.ts` and `src/server/params.ts` explains the param-safety contract by naming `paramSafeColumnsOrFallback()`, which application code will no longer be able to call. Rewording published TSDoc is a documentation-affecting change and would need its own bump under `AGENTS.md`, so it is better folded into a PR that already carries one.
