### PR TITLE
Bump to 3.11.3 — changelog for the paramSafeColumnsOrFallback typed back-door (#532)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.11.3
+
+- Psychic's two `paramSafeColumnsOrFallback` call sites now reach the member through a typed bracket-access back-door — cast to `(this: T) => string[]` and invoked with an explicit receiver — so psychic keeps compiling and linting when dream makes `Dream.paramSafeColumnsOrFallback` `private static` (dream 2.26.0, closing the explicit route back to advertising a model's whole writable surface in OpenAPI request bodies). No consumer-observable behavior change. Also corrects a stale dream line-range citation in a `paramSafeColumnNamesFromCliTokens.ts` comment. (Shipped in #532, which landed without a bump; this release carries it.)
+
 ## 3.11.2
 
 - Errors thrown while generating the per-`openapiName` OpenAPI cache during `PsychicApp.init` (e.g. a serializer misconfiguration) are now wrapped with context naming the step and the failing document — "Failed to generate the OpenAPI document 'default' during PsychicApp.init." — with the original error preserved via `{ cause }` (and its message embedded). Previously the underlying error propagated raw, with nothing tying it to OpenAPI generation or identifying which document failed. Other documents and the success path are unchanged.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic",
   "description": "Typescript web framework",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "author": "RVOHealth",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
PR #532 (the `paramSafeColumnsOrFallback` typed back-door) merged without a version bump or changelog entry — it was stacked on #531, which carried the 3.11.2 bump, and 3.11.2 published before #532 landed. This PR carries #532's change as 3.11.3: `package.json` bump and a CHANGELOG entry, nothing else.

Per request: no local verification run on this branch (version + changelog only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wykh7CCKwEL5VRx1uD8VEY
